### PR TITLE
Fixed positioning and dimension issues on king studs, headers and sills

### DIFF
--- a/src/config/framing.py
+++ b/src/config/framing.py
@@ -178,17 +178,15 @@ FRAMING_PARAMS: Dict[str, Any] = {
     # King stud parameters
     "king_stud_width": 1.5/12,      # 1.5 inches in feet
     "king_stud_depth": 3.5/12,      # 3.5 inches in feet (depth along wall)
-    "king_stud_spacing": 16.0/12,   # 16 inches in feet
 
     # Trimmer parameters
     "trimmer_width": 1.5/12,      # 1.5 inches in feet
     "trimmer_depth": 3.5/12,      # 3.5 inches in feet (depth along wall)
-    "trimmer_spacing": 16.0/12,   # 16 inches in feet
 
     # Header parameters
-    "header_width": 1.5/12,      # 1.5 inches in feet
+    "header_height": 7/12,      # 1.5 inches in feet
     "header_depth": 3.5/12,      # 3.5 inches in feet (depth along wall)
-    "header_spacing": 16.0/12,   # 16 inches in feet
+    "header_height_above_opening": 0.0,  # 0 inches in feet
 
     # Cripple parameters
     "cripple_width": 1.5/12,      # 1.5 inches in feet
@@ -198,12 +196,11 @@ FRAMING_PARAMS: Dict[str, Any] = {
     # Sill parameters
     "sill_width": 1.5/12,      # 1.5 inches in feet
     "sill_depth": 3.5/12,      # 3.5 inches in feet (depth along wall)
-    "sill_spacing": 16.0/12,   # 16 inches in feet
     
     # Offsets and tolerances
     "minimum_stud_spacing": 16.0/12,  # 16 inches in feet
-    "trimmer_offset": 0.5/12,         # 0.5 inches in feet
-    "king_stud_offset": 0.5/12,       # 0.5 inches in feet
+    "trimmer_offset": 1.5/12/2,         # 0.5 inches in feet
+    "king_stud_offset": 1.5/12/2,       # 0.5 inches in feet
     
     # Validation thresholds
     "minimum_cell_width": 1.5/12,     # 1.5 inches in feet

--- a/src/framing_elements/header_parameters.py
+++ b/src/framing_elements/header_parameters.py
@@ -52,7 +52,7 @@ class HeaderParameters:
             profile = get_profile_for_wall_type(wall_type)
             
         # Get default header parameters from config
-        header_height = FRAMING_PARAMS.get("header_height", profile.width * 2)
+        header_height = FRAMING_PARAMS.get("header_height", profile.width * 2) # TEMPORARILY NOT USING HEADER HEIGHT
         
         # For headers, typical orientation is:
         # - thickness = profile.thickness (depth along wall)

--- a/src/framing_elements/king_studs.py
+++ b/src/framing_elements/king_studs.py
@@ -50,8 +50,8 @@ def create_king_studs(
         # Extract dimensions
         stud_width = framing_params.get("stud_width", 1.5/12)
         stud_depth = framing_params.get("stud_depth", 3.5/12)
-        trimmer_width = framing_params.get("trimmer_width", 3.5/12)
-        king_stud_width = framing_params.get("king_stud_width", 3.5/12)
+        trimmer_width = framing_params.get("trimmer_width", 1.5/12)
+        king_stud_width = framing_params.get("king_stud_width", 1.5/12)
         
         print("\nDimensions:")
         print(f"  Stud width: {stud_width}")
@@ -71,9 +71,8 @@ def create_king_studs(
         opening_start = opening_data["start_u_coordinate"]
         opening_width = opening_data["rough_width"]
         
-        left_u = opening_start - (trimmer_width + king_stud_width)
-        right_u = opening_start + opening_width + trimmer_width + king_stud_width
-
+        left_u = opening_start - trimmer_width - (king_stud_width / 2)
+        right_u = opening_start + opening_width + trimmer_width + (king_stud_width / 2)
         # Print the calculated positions
         print("\nPosition calculations:")
         print(f"Opening start: {opening_start}")
@@ -201,7 +200,7 @@ class KingStudGenerator:
         # Create plate data dictionary with the correct keys
         plate_data = {
             "bottom_plate_elevation": bottom_data["boundary_elevation"],
-            "top_elevation": top_data["reference_elevation"],  # Changed from boundary_elevation
+            "top_elevation": top_data["boundary_elevation"],  # Changed from boundary_elevation
             "plate_thickness": bottom_data["thickness"]
         }
         

--- a/src/framing_elements/sills.py
+++ b/src/framing_elements/sills.py
@@ -165,27 +165,25 @@ class SillGenerator:
             print("Using fallback method for sill generation")
             
             # Extract opening information
-            opening_u_start = opening_data["start_u_coordinate"]
-            opening_width = opening_data["rough_width"]
-            opening_v_start = opening_data["base_elevation_relative_to_wall_base"]
+            opening_u_start = opening_data.get("start_u_coordinate")
+            opening_width = opening_data.get("rough_width")
+            opening_v_start = opening_data.get("base_elevation_relative_to_wall_base")
+
+            # Calculate sill box dimensions
+            sill_width = FRAMING_PARAMS.get("sill_width", 1.5/12)
+            sill_depth = FRAMING_PARAMS.get("sill_depth", 3.5/12)
+            sill_length = opening_width
             
             # Get the base plane from wall data
             base_plane = self.wall_data.get("base_plane")
             if base_plane is None:
                 print("No base plane available for fallback sill generation")
                 return None
-                
-            # Get sill dimensions
-            sill_height = 0.25  # Default height (3 inches)
-            sill_width = 0.292  # Default width (3.5 inches)
             
             # Calculate sill center point (centered horizontally below the opening)
             sill_center_u = opening_u_start + opening_width / 2
-            sill_center_v = opening_v_start - sill_height / 2  # Center vertically below the opening
+            sill_center_v = opening_v_start - sill_width / 2  # Center vertically below the opening
             sill_center = base_plane.PointAt(sill_center_u, sill_center_v, 0)
-            
-            # Create sill length based on opening width plus some extension
-            sill_length = opening_width + 0.5  # Add 6 inches total (3 on each side)
             
             try:
                 # Create box with proper orientation
@@ -200,7 +198,7 @@ class SillGenerator:
                     box_plane,
                     rg.Interval(-sill_length/2, sill_length/2),  # Length along x-axis
                     rg.Interval(-sill_width/2, sill_width/2),    # Width into the wall
-                    rg.Interval(-sill_height/2, sill_height/2)   # Height centered on sill_center
+                    rg.Interval(-sill_depth/2, sill_depth/2)   # Height centered on sill_center
                 )
                 
                 # Convert to Brep


### PR DESCRIPTION
- King studs were being generated farther away from the openings than needed, fixed.
- Headers were overlapping with windows and their length was longer than needed; width and depth dimensions were swapped, fixed.
- Sills were overlapping with windows, fixed.