### PR TITLE
Phase 9: MEP Route Visualization Component

### DIFF
--- a/PRPs/PRP-019--mep-routing-visualizer.md
+++ b/PRPs/PRP-019--mep-routing-visualizer.md
@@ -1,0 +1,121 @@
+# PRP-019: MEP Route Visualization Component
+
+## Overview
+
+**Feature**: Route Visualization GHPython Component
+**Branch**: `feature/mep-routing-phase9-visualizer`
+**Issue**: #33 - MEP Routing Solver: OAHS Implementation Plan (Phase 9)
+
+## Problem Statement
+
+Routes computed by OAHS need to be visualized in Rhino:
+
+1. **Curve Generation**: Convert route segments to RhinoCommon curves
+2. **Color Coding**: Distinguish system types visually
+3. **Junction Markers**: Show Steiner/junction points
+4. **Debug Visualization**: Display graph edges and occupancy
+
+## Solution Design
+
+### 1. GHPython Component: gh_mep_route_visualizer.py
+
+**Inputs:**
+- `routes_json`: JSON string with computed routes
+- `color_by_system`: Boolean to enable system-type coloring
+- `show_junctions`: Boolean to show junction points
+- `show_occupancy`: Boolean to visualize reserved space
+
+**Outputs:**
+- `curves`: Route curves (colored by system)
+- `colors`: Color list matching curves
+- `points`: Junction/Steiner points
+- `info`: Diagnostic information
+
+### 2. System Color Scheme
+
+| System Type | Color | RGB |
+|-------------|-------|-----|
+| Sanitary Drain | Brown | (139, 90, 43) |
+| Sanitary Vent | Gray | (128, 128, 128) |
+| DHW | Red | (255, 0, 0) |
+| DCW | Blue | (0, 0, 255) |
+| Power | Yellow | (255, 255, 0) |
+| Data | Orange | (255, 165, 0) |
+| Lighting | White | (255, 255, 255) |
+
+### 3. Coordinate Transformation
+
+Routes use 2D plane coordinates (U, V). Need to transform to 3D world:
+
+```python
+def transform_to_world(segment, domain_info):
+    """Transform 2D route segment to 3D world coordinates."""
+    if domain_info["type"] == "wall":
+        # Wall plane: U along wall, V vertical
+        plane = domain_info["base_plane"]
+        start_3d = plane.PointAt(segment.start[0], segment.start[1])
+        end_3d = plane.PointAt(segment.end[0], segment.end[1])
+    elif domain_info["type"] == "floor":
+        # Floor plane: X, Y horizontal
+        z = domain_info["elevation"]
+        start_3d = Point3d(segment.start[0], segment.start[1], z)
+        end_3d = Point3d(segment.end[0], segment.end[1], z)
+    return start_3d, end_3d
+```
+
+### 4. Assembly-Safe Geometry
+
+Must use RhinoCommonFactory for correct assembly:
+
+```python
+from src.timber_framing_generator.utils.geometry_factory import get_factory
+
+factory = get_factory()
+line = factory.create_line(start_3d, end_3d)
+curve = factory.create_polyline_curve(points)
+```
+
+## Implementation Steps
+
+### Step 1: Basic Curve Generation
+- Parse routes_json
+- Create line curves for each segment
+- Return as DataTree
+
+### Step 2: Color Coding
+- System type color mapping
+- Apply colors to curves
+- Return color list
+
+### Step 3: Junction Points
+- Extract Steiner points from routes
+- Create point markers
+- Optional display
+
+### Step 4: Debug Visualization
+- Graph edge display
+- Occupancy region display
+- Node labels
+
+## File Structure
+
+```
+scripts/
+    gh_mep_route_visualizer.py  # Main visualization component
+```
+
+## Test Cases
+
+1. Single route → single colored curve
+2. Multiple routes → correct colors per system
+3. Route with junctions → points displayed
+4. Empty routes_json → graceful handling
+
+## Exit Criteria
+
+- [ ] gh_mep_route_visualizer.py component created
+- [ ] Routes display as curves in Rhino
+- [ ] System types color-coded correctly
+- [ ] Works with RhinoCommonFactory
+- [ ] Junction points optionally shown
+- [ ] Component documented

--- a/scripts/gh_mep_route_visualizer.py
+++ b/scripts/gh_mep_route_visualizer.py
@@ -1,0 +1,566 @@
+# File: scripts/gh_mep_route_visualizer.py
+"""MEP Route Visualizer for Grasshopper.
+
+Converts MEP route JSON from the OAHS routing algorithm into visual Rhino
+geometry for display and inspection. This component is the visualization
+endpoint of the MEP routing pipeline.
+
+Key Features:
+1. Route Visualization
+   - Converts route segments to Line/Curve geometry
+   - Supports system-type based color coding
+   - Creates junction/Steiner point markers
+
+2. System Color Coding
+   - Distinct colors for each MEP system type
+   - sanitary_drain (Brown), sanitary_vent (Gray)
+   - dhw (Red), dcw (Blue), power (Yellow)
+   - data (Orange), lighting (White)
+
+3. DataTree Output
+   - One branch per route for curves and points
+   - Enables per-route selection and analysis
+   - Compatible with downstream visualization tools
+
+Environment:
+    Rhino 8
+    Grasshopper
+    Python component (CPython 3)
+
+Dependencies:
+    - Rhino.Geometry: Core geometry creation (via RhinoCommonFactory)
+    - Grasshopper: DataTree and component framework
+    - System.Drawing: Color definitions for visualization
+    - json: Parsing route data from upstream components
+    - timber_framing_generator: RhinoCommonFactory for assembly-safe geometry
+
+Performance Considerations:
+    - Linear scaling with number of routes and segments
+    - Geometry creation via factory adds minimal overhead
+    - For >100 routes, consider filtering by system type
+
+Usage:
+    1. Connect routes_json from MEP Router component
+    2. Optionally toggle color_by_system for system-type coloring
+    3. Optionally toggle show_junctions to display junction points
+    4. Set run=True to execute visualization
+    5. Connect curves output to Preview or other display components
+
+Input Requirements:
+    Routes JSON (routes_json) - str:
+        JSON string containing computed routes from OAHS router.
+        Must have "routes" array with route objects containing
+        "segments" (with start/end coords) and optional "junctions".
+        Required: Yes
+        Access: Item
+
+    Color by System (color_by_system) - bool:
+        Enable system-type based color coding for route curves.
+        Required: No (defaults to True)
+        Access: Item
+
+    Show Junctions (show_junctions) - bool:
+        Display junction/Steiner points as Point3d geometry.
+        Required: No (defaults to True)
+        Access: Item
+
+    Run (run) - bool:
+        Trigger to execute visualization. Set True to process.
+        Required: Yes
+        Access: Item
+
+Outputs:
+    Curves (curves) - DataTree[Curve]:
+        Route curves as LineCurves, one branch per route.
+        Connect to Preview component for visualization.
+
+    Colors (colors) - List[System.Drawing.Color]:
+        Color list matching curves for system-type visualization.
+        Use with Custom Preview for colored display.
+
+    Points (points) - DataTree[Point3d]:
+        Junction/Steiner points, one branch per route.
+        Useful for debugging routing decisions.
+
+    Info (info) - str:
+        Diagnostic information string with processing summary.
+
+Technical Details:
+    - Uses RhinoCommonFactory for all geometry creation
+    - Colors use System.Drawing.Color for GH compatibility
+    - DataTrees preserve route-level grouping for selection
+    - Empty/invalid JSON returns empty outputs gracefully
+
+Error Handling:
+    - Invalid JSON logs warning and returns empty outputs
+    - Missing fields in route data are skipped with warning
+    - Geometry creation failures logged but don't halt processing
+    - run=False returns immediately with "Disabled" info message
+
+Author: Fernando Maytorena
+Version: 1.0.0
+"""
+
+# =============================================================================
+# Imports
+# =============================================================================
+
+# Standard library
+import sys
+import json
+import traceback
+
+# .NET / CLR
+import clr
+clr.AddReference("Grasshopper")
+clr.AddReference("RhinoCommon")
+clr.AddReference("System.Drawing")
+
+from System import Array
+from System.Collections.Generic import List
+from System.Drawing import Color
+
+# Rhino / Grasshopper
+import Rhino
+import Rhino.Geometry as rg
+import Grasshopper
+from Grasshopper import DataTree
+from Grasshopper.Kernel.Data import GH_Path
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+COMPONENT_NAME = "MEP Route Visualizer"
+COMPONENT_NICKNAME = "MEP-Viz"
+COMPONENT_MESSAGE = "v1.0.0"
+COMPONENT_CATEGORY = "TimberFraming"
+COMPONENT_SUBCATEGORY = "MEP"
+
+# System color mapping: system_type -> (R, G, B)
+SYSTEM_COLORS = {
+    "sanitary_drain": (139, 90, 43),      # Brown
+    "sanitary_vent": (128, 128, 128),     # Gray
+    "dhw": (255, 0, 0),                   # Red
+    "dcw": (0, 0, 255),                   # Blue
+    "power": (255, 255, 0),               # Yellow
+    "data": (255, 165, 0),                # Orange
+    "lighting": (255, 255, 255),          # White
+    "default": (0, 255, 0),               # Green
+}
+
+# =============================================================================
+# Logging Utilities
+# =============================================================================
+
+def log_message(message, level="info"):
+    """Log to console and optionally add GH runtime message.
+
+    Args:
+        message: The message to log
+        level: One of "info", "debug", "warning", "error", "remark"
+    """
+    # Always print to console (captured by 'out' parameter and log files)
+    print(f"[{level.upper()}] {message}")
+
+    # Add to GH component UI for warnings and errors
+    if level == "warning":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Warning, message)
+    elif level == "error":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Error, message)
+    elif level == "remark":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Remark, message)
+
+
+def log_debug(message):
+    """Log debug message (console only)."""
+    print(f"[DEBUG] {message}")
+
+
+def log_info(message):
+    """Log info message (console only)."""
+    print(f"[INFO] {message}")
+
+
+def log_warning(message):
+    """Log warning message (console + GH UI)."""
+    log_message(message, "warning")
+
+
+def log_error(message):
+    """Log error message (console + GH UI)."""
+    log_message(message, "error")
+
+# =============================================================================
+# Component Setup
+# =============================================================================
+
+def setup_component():
+    """Initialize and configure the Grasshopper component.
+
+    This function handles:
+    1. Setting component metadata (name, category, etc.)
+    2. Configuring input parameter names, descriptions, and access
+    3. Configuring output parameter names and descriptions
+
+    Note: Output[0] is reserved for GH's internal 'out' - start from Output[1]
+
+    IMPORTANT: Type Hints cannot be set programmatically in Rhino 8.
+    They must be configured via UI: Right-click input -> Type hint -> Select type
+    """
+    # Component metadata
+    ghenv.Component.Name = COMPONENT_NAME
+    ghenv.Component.NickName = COMPONENT_NICKNAME
+    ghenv.Component.Message = COMPONENT_MESSAGE
+    ghenv.Component.Category = COMPONENT_CATEGORY
+    ghenv.Component.SubCategory = COMPONENT_SUBCATEGORY
+
+    # Configure inputs
+    # IMPORTANT: In GHPython, the NickName becomes the Python variable name!
+    # Format: (DisplayName, variable_name, Description, Access)
+    # - Name: Human-readable display name (shown in tooltips)
+    # - NickName: MUST be valid Python identifier - this IS the variable name in code
+    # - Access: item, list, or tree
+    #
+    # NOTE: Type Hints must be set via GH UI (right-click -> Type hint)
+    # They cannot be set programmatically from within the script.
+    inputs = ghenv.Component.Params.Input
+
+    input_config = [
+        # (DisplayName, variable_name, Description, Access)
+        ("Routes JSON", "routes_json", "JSON string with computed routes from OAHS router",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Color by System", "color_by_system", "Enable system-type color coding (default True)",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Show Junctions", "show_junctions", "Display junction/Steiner points (default True)",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Run", "run", "Boolean to trigger execution",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+    ]
+
+    for i, (name, nick, desc, access) in enumerate(input_config):
+        if i < inputs.Count:
+            inputs[i].Name = name
+            inputs[i].NickName = nick
+            inputs[i].Description = desc
+            inputs[i].Access = access
+
+    # Configure outputs (start from index 1, as 0 is reserved for 'out')
+    # IMPORTANT: NickName becomes the Python variable name - must match code!
+    outputs = ghenv.Component.Params.Output
+
+    output_config = [
+        # (DisplayName, variable_name, Description) - indices start at 1
+        ("Curves", "curves", "Route curves as LineCurves (DataTree, one branch per route)"),
+        ("Colors", "colors", "System.Drawing.Color list matching curves"),
+        ("Points", "points", "Junction/Steiner points (DataTree, one branch per route)"),
+        ("Info", "info", "Diagnostic information string"),
+    ]
+
+    for i, (name, nick, desc) in enumerate(output_config):
+        idx = i + 1  # Skip Output[0]
+        if idx < outputs.Count:
+            outputs[idx].Name = name
+            outputs[idx].NickName = nick
+            outputs[idx].Description = desc
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def get_factory():
+    """Get RhinoCommonFactory instance for geometry creation.
+
+    Returns:
+        RhinoCommonFactory instance
+
+    Raises:
+        ImportError: If timber_framing_generator is not installed
+    """
+    from src.timber_framing_generator.utils.geometry_factory import get_factory as _get_factory
+    return _get_factory()
+
+
+def get_system_color(system_type, color_by_system=True):
+    """Get System.Drawing.Color for a system type.
+
+    Args:
+        system_type: MEP system type string (e.g., "sanitary_drain", "dhw")
+        color_by_system: If False, return default green for all systems
+
+    Returns:
+        System.Drawing.Color instance
+    """
+    if not color_by_system:
+        rgb = SYSTEM_COLORS["default"]
+    else:
+        # Normalize system type (lowercase, strip whitespace)
+        system_key = system_type.lower().strip() if system_type else "default"
+        rgb = SYSTEM_COLORS.get(system_key, SYSTEM_COLORS["default"])
+
+    return Color.FromArgb(255, rgb[0], rgb[1], rgb[2])
+
+
+def validate_inputs(routes_json_input, run_input):
+    """Validate component inputs.
+
+    Args:
+        routes_json_input: Routes JSON string to validate
+        run_input: Run boolean input
+
+    Returns:
+        tuple: (is_valid, error_message)
+    """
+    if not run_input:
+        return False, "Set run=True to execute visualization"
+
+    if not routes_json_input:
+        return False, "Missing routes_json input"
+
+    # Validate JSON parsing
+    try:
+        data = json.loads(routes_json_input)
+        if not isinstance(data, dict):
+            return False, "routes_json must be a JSON object"
+        if "routes" not in data:
+            return False, "routes_json missing 'routes' key"
+    except json.JSONDecodeError as e:
+        return False, f"Invalid routes_json: {e}"
+
+    return True, None
+
+
+def parse_routes(routes_json_str):
+    """Parse routes from JSON string.
+
+    Args:
+        routes_json_str: JSON string with routes data
+
+    Returns:
+        List of route dictionaries
+    """
+    data = json.loads(routes_json_str)
+    return data.get("routes", [])
+
+
+def create_route_curves(route, factory):
+    """Create LineCurve geometry for route segments.
+
+    Args:
+        route: Route dictionary with "segments" list
+        factory: RhinoCommonFactory instance
+
+    Returns:
+        List of LineCurve objects from RhinoCommon assembly
+    """
+    curves = []
+    segments = route.get("segments", [])
+
+    for seg in segments:
+        start_coords = seg.get("start")
+        end_coords = seg.get("end")
+
+        if not start_coords or not end_coords:
+            log_debug(f"Skipping segment with missing start/end in route {route.get('route_id', 'unknown')}")
+            continue
+
+        if len(start_coords) < 3 or len(end_coords) < 3:
+            log_debug(f"Skipping segment with incomplete coordinates")
+            continue
+
+        try:
+            # Use factory to create LineCurve (ensures RhinoCommon assembly)
+            line_curve = factory.create_line_curve(
+                tuple(start_coords[:3]),
+                tuple(end_coords[:3])
+            )
+            if line_curve is not None:
+                curves.append(line_curve)
+        except Exception as e:
+            log_debug(f"Error creating line curve: {e}")
+            continue
+
+    return curves
+
+
+def create_junction_points(route, factory):
+    """Create Point3d geometry for route junctions.
+
+    Args:
+        route: Route dictionary with "junctions" list
+        factory: RhinoCommonFactory instance
+
+    Returns:
+        List of Point3d objects from RhinoCommon assembly
+    """
+    points = []
+    junctions = route.get("junctions", [])
+
+    for junction in junctions:
+        if not junction or len(junction) < 3:
+            log_debug(f"Skipping junction with incomplete coordinates")
+            continue
+
+        try:
+            # Use factory to create Point3d (ensures RhinoCommon assembly)
+            pt = factory.create_point3d(
+                float(junction[0]),
+                float(junction[1]),
+                float(junction[2])
+            )
+            if pt is not None:
+                points.append(pt)
+        except Exception as e:
+            log_debug(f"Error creating junction point: {e}")
+            continue
+
+    return points
+
+
+def process_routes(routes_json_str, color_by_system, show_junctions):
+    """Process route data and generate visualization geometry.
+
+    Args:
+        routes_json_str: JSON string with routes data
+        color_by_system: Enable system-type color coding
+        show_junctions: Include junction points in output
+
+    Returns:
+        tuple: (curves_tree, colors_list, points_tree, info_string)
+    """
+    log_info("Starting route visualization processing")
+
+    # Get geometry factory
+    try:
+        factory = get_factory()
+    except ImportError as e:
+        log_error(f"Could not import geometry factory: {e}")
+        return DataTree[object](), [], DataTree[object](), f"Import error: {e}"
+
+    # Parse routes
+    routes = parse_routes(routes_json_str)
+    log_info(f"Parsed {len(routes)} routes")
+
+    # Initialize output structures
+    curves_tree = DataTree[object]()
+    points_tree = DataTree[object]()
+    colors_list = []
+
+    # Track statistics
+    total_curves = 0
+    total_points = 0
+    system_counts = {}
+
+    # Process each route
+    for route_idx, route in enumerate(routes):
+        route_id = route.get("route_id", f"route_{route_idx}")
+        system_type = route.get("system_type", "default")
+
+        log_debug(f"Processing route {route_id} (system: {system_type})")
+
+        # Track system counts
+        system_counts[system_type] = system_counts.get(system_type, 0) + 1
+
+        # Create path for this route
+        path = GH_Path(route_idx)
+
+        # Create route curves
+        route_curves = create_route_curves(route, factory)
+        for curve in route_curves:
+            curves_tree.Add(curve, path)
+            # Add color for each curve
+            colors_list.append(get_system_color(system_type, color_by_system))
+        total_curves += len(route_curves)
+
+        # Create junction points if requested
+        if show_junctions:
+            route_points = create_junction_points(route, factory)
+            for pt in route_points:
+                points_tree.Add(pt, path)
+            total_points += len(route_points)
+
+    # Build info string
+    info_lines = [
+        f"Routes processed: {len(routes)}",
+        f"Total curve segments: {total_curves}",
+        f"Total junction points: {total_points}",
+        "System breakdown:",
+    ]
+    for sys_type, count in sorted(system_counts.items()):
+        info_lines.append(f"  - {sys_type}: {count} routes")
+
+    info_string = "\n".join(info_lines)
+    log_info(f"Visualization complete: {total_curves} curves, {total_points} points")
+
+    return curves_tree, colors_list, points_tree, info_string
+
+# =============================================================================
+# Main Function
+# =============================================================================
+
+def main():
+    """Main entry point for the component.
+
+    Coordinates the overall workflow:
+    1. Setup component metadata
+    2. Validate inputs
+    3. Process route data
+    4. Return visualization geometry
+
+    Returns:
+        tuple: (curves, colors, points, info) or empty outputs on failure
+    """
+    # Setup component
+    setup_component()
+
+    # Initialize empty outputs
+    empty_curves = DataTree[object]()
+    empty_colors = []
+    empty_points = DataTree[object]()
+
+    try:
+        # Get inputs (these come from GH component inputs)
+        # Use globals() to check if variables are defined
+        routes_json_input = routes_json if 'routes_json' in dir() else None
+        color_by_system_input = color_by_system if 'color_by_system' in dir() else True
+        show_junctions_input = show_junctions if 'show_junctions' in dir() else True
+        run_input = run if 'run' in dir() else False
+
+        # Handle None/unset boolean inputs with defaults
+        if color_by_system_input is None:
+            color_by_system_input = True
+        if show_junctions_input is None:
+            show_junctions_input = True
+
+        # Validate inputs
+        is_valid, error_msg = validate_inputs(routes_json_input, run_input)
+        if not is_valid:
+            if error_msg and "run=True" not in error_msg:
+                log_warning(error_msg)
+            return empty_curves, empty_colors, empty_points, error_msg or "Disabled"
+
+        # Process routes
+        curves_tree, colors_list, points_tree, info_string = process_routes(
+            routes_json_input,
+            color_by_system_input,
+            show_junctions_input
+        )
+
+        return curves_tree, colors_list, points_tree, info_string
+
+    except Exception as e:
+        log_error(f"Unexpected error: {str(e)}")
+        log_debug(traceback.format_exc())
+        return empty_curves, empty_colors, empty_points, f"Error: {str(e)}"
+
+# =============================================================================
+# Execution
+# =============================================================================
+
+if __name__ == "__main__":
+    # Execute main and assign to output variables
+    # These variable names must match your GH component outputs
+    curves, colors, points, info = main()


### PR DESCRIPTION
## Summary
- Implement GHPython component for visualizing OAHS routing results
- System-type color coding (sanitary=brown, DHW=red, DCW=blue, power=yellow, etc.)
- Junction point markers for debugging Steiner points
- DataTree output preserves route-level grouping

## Changes
- Add `scripts/gh_mep_route_visualizer.py` - Main visualization component
- Add `PRPs/PRP-019--mep-routing-visualizer.md` - Component specification

## Test plan
- [ ] Load component in Grasshopper
- [ ] Connect routes_json from MEP Router
- [ ] Verify curves display with correct colors
- [ ] Verify junction points displayed when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)