### PR TITLE
Phase 10: Penetration Generator Integration

### DIFF
--- a/PRPs/PRP-020--mep-routing-penetrations.md
+++ b/PRPs/PRP-020--mep-routing-penetrations.md
@@ -1,0 +1,128 @@
+# PRP-020: MEP Routing Penetration Generator Integration
+
+## Overview
+
+**Feature**: Penetration Generator Integration for MEP Routes
+**Branch**: `feature/mep-routing-phase10-penetrations`
+**Issue**: #33 - MEP Routing Solver: OAHS Implementation Plan (Phase 10)
+
+## Problem Statement
+
+Routes computed by OAHS need to produce penetration specifications:
+
+1. **Route-to-Penetration**: Convert route segments to penetration specs
+2. **Code Compliance**: Validate against 40% member depth limit
+3. **Reinforcement**: Flag penetrations needing structural reinforcement
+4. **GHPython Component**: Visual feedback in Grasshopper
+
+## Existing Code
+
+### penetration_rules.py
+- `generate_plumbing_penetrations(routes, framing_elements)` - Main function
+- `MAX_PENETRATION_RATIO = 0.40` - Code limit
+- `REINFORCEMENT_THRESHOLD = 0.33` - Above this, reinforcement required
+- `PLUMBING_PENETRATION_CLEARANCE = 0.0208` (1/4" clearance)
+
+### base.py
+- `calculate_penetration_size(pipe_diameter, clearance)` - Hole diameter calc
+- `check_penetration_allowed(hole_diameter, member_depth, max_ratio)` - Validation
+
+## Solution Design
+
+### 1. Penetration Integration Module
+
+**File**: `src/timber_framing_generator/mep/routing/penetration_integration.py`
+
+Bridge between OAHS routes_json and existing penetration_rules:
+
+```python
+def integrate_routes_to_penetrations(
+    routes_json: str,
+    framing_json: str
+) -> Dict[str, Any]:
+    """
+    Convert OAHS routes to penetration specifications.
+
+    Args:
+        routes_json: JSON from gh_mep_router
+        framing_json: JSON from gh_framing_generator
+
+    Returns:
+        Penetrations JSON with validation results
+    """
+```
+
+### 2. GHPython Component
+
+**File**: `scripts/gh_mep_penetration_generator.py`
+
+**Inputs**:
+- `routes_json`: From MEP Router
+- `framing_json`: From Framing Generator
+- `clearance`: Pipe clearance (default 0.25")
+- `run`: Boolean trigger
+
+**Outputs**:
+- `penetrations_json`: Full penetration specs
+- `allowed_pts`: Point3d for allowed penetrations
+- `blocked_pts`: Point3d for blocked penetrations
+- `reinforce_pts`: Point3d needing reinforcement
+- `info`: Diagnostic summary
+
+### 3. Output JSON Schema
+
+```json
+{
+  "penetrations": [
+    {
+      "id": "pen_route_001_stud_123",
+      "route_id": "route_001",
+      "element_id": "stud_123",
+      "element_type": "stud",
+      "location": {"x": 10.5, "y": 2.0, "z": 4.5},
+      "diameter": 0.125,
+      "pipe_size": 0.0625,
+      "system_type": "sanitary_drain",
+      "is_allowed": true,
+      "reinforcement_required": false,
+      "penetration_ratio": 0.28,
+      "warning": null
+    }
+  ],
+  "summary": {
+    "total": 15,
+    "allowed": 12,
+    "blocked": 3,
+    "reinforcement_required": 2
+  }
+}
+```
+
+## Implementation Steps
+
+### Step 1: Penetration Integration Module
+- Parse routes_json and framing_json
+- Convert route segments to MEPRoute format
+- Call existing `generate_plumbing_penetrations`
+- Return structured JSON
+
+### Step 2: GHPython Component
+- Follow grasshopper-python-assistant template
+- Use RhinoCommonFactory for points
+- Color code by status (green/red/orange)
+- DataTree for route-grouped output
+
+### Step 3: Integration Tests
+- Test route → penetration conversion
+- Test code compliance validation
+- Test reinforcement flagging
+
+## Exit Criteria
+
+- [ ] penetration_integration.py module created
+- [ ] gh_mep_penetration_generator.py component created
+- [ ] Routes produce valid penetration specs
+- [ ] Penetrations respect code limits (40% max)
+- [ ] Reinforcement flagged when ratio > 33%
+- [ ] Integration tests passing
+- [ ] Component documented

--- a/scripts/gh_mep_penetration_generator.py
+++ b/scripts/gh_mep_penetration_generator.py
@@ -1,0 +1,507 @@
+# File: scripts/gh_mep_penetration_generator.py
+"""MEP Penetration Generator for Grasshopper.
+
+Converts MEP routes to penetration specifications with code compliance validation.
+This component bridges the OAHS routing output to existing penetration rules,
+producing validated penetration specs with code compliance and reinforcement flags.
+
+Key Features:
+1. Route-to-Penetration Conversion
+   - Parses routes_json from MEP Router
+   - Intersects routes with framing elements
+   - Generates penetration specifications
+
+2. Code Compliance Validation
+   - Checks penetration size vs member depth
+   - Flags blocked penetrations exceeding limits
+   - Identifies penetrations requiring reinforcement
+
+3. Visual Status Feedback
+   - Allowed penetrations (green points)
+   - Blocked penetrations (red points)
+   - Reinforcement required (orange points)
+
+Environment:
+    Rhino 8
+    Grasshopper
+    Python component (CPython 3)
+
+Dependencies:
+    - Rhino.Geometry: Core geometry creation (via RhinoCommonFactory)
+    - Grasshopper: DataTree and component framework
+    - json: Parsing route and framing data
+    - timber_framing_generator: RhinoCommonFactory for assembly-safe geometry
+    - penetration_integration: Route-to-penetration logic with code compliance
+
+Performance Considerations:
+    - Linear scaling with number of routes and framing elements
+    - Geometry creation via factory adds minimal overhead
+    - For >100 routes, ensure framing_json is well-structured
+
+Usage:
+    1. Connect routes_json from MEP Router component
+    2. Connect framing_json from Framing Generator component
+    3. Optionally adjust clearance (default 0.0208 ft = 1/4")
+    4. Set run=True to execute penetration analysis
+    5. Connect point outputs to Preview with appropriate colors
+
+Input Requirements:
+    Routes JSON (routes_json) - str:
+        JSON string containing computed routes from OAHS router.
+        Must have "routes" array with route objects containing
+        "segments" (with start/end coords) and system_type.
+        Required: Yes
+        Access: Item
+
+    Framing JSON (framing_json) - str:
+        JSON string containing framing elements from Framing Generator.
+        Elements need centerlines and profile information for
+        penetration validation.
+        Required: Yes
+        Access: Item
+
+    Clearance (clearance) - float:
+        Pipe clearance in feet added around penetrations.
+        Required: No (defaults to 0.0208 = 1/4")
+        Access: Item
+
+    Run (run) - bool:
+        Trigger to execute penetration analysis. Set True to process.
+        Required: Yes
+        Access: Item
+
+Outputs:
+    Penetrations JSON (penetrations_json) - str:
+        Full penetration specifications as JSON string with
+        location, size, is_allowed, reinforcement_required flags.
+
+    Allowed Points (allowed_pts) - List[Point3d]:
+        Point3d for allowed penetrations (display green).
+        No code violations.
+
+    Blocked Points (blocked_pts) - List[Point3d]:
+        Point3d for blocked penetrations (display red).
+        Exceed code limits - require rerouting.
+
+    Reinforce Points (reinforce_pts) - List[Point3d]:
+        Point3d needing reinforcement (display orange).
+        Allowed but require structural reinforcement.
+
+    Info (info) - str:
+        Diagnostic summary string with processing statistics.
+
+Technical Details:
+    - Uses RhinoCommonFactory for all geometry creation
+    - Code limits based on IRC/building code penetration rules
+    - Penetration ratio checked against member depth
+    - JSON output compatible with downstream components
+
+Error Handling:
+    - Invalid JSON logs warning and returns empty outputs
+    - Missing fields in route/framing data are skipped with warning
+    - Geometry creation failures logged but don't halt processing
+    - run=False returns immediately with "Disabled" info message
+
+Author: Fernando Maytorena
+Version: 1.0.0
+"""
+
+# =============================================================================
+# Imports
+# =============================================================================
+
+# Standard library
+import sys
+import json
+import traceback
+
+# .NET / CLR
+import clr
+clr.AddReference("Grasshopper")
+clr.AddReference("RhinoCommon")
+
+from System import Array
+from System.Collections.Generic import List
+
+# Rhino / Grasshopper
+import Rhino
+import Rhino.Geometry as rg
+import Grasshopper
+from Grasshopper import DataTree
+from Grasshopper.Kernel.Data import GH_Path
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+COMPONENT_NAME = "MEP Penetration Generator"
+COMPONENT_NICKNAME = "MEP-Pen"
+COMPONENT_MESSAGE = "v1.0.0"
+COMPONENT_CATEGORY = "TimberFraming"
+COMPONENT_SUBCATEGORY = "MEP"
+
+DEFAULT_CLEARANCE = 0.0208  # 1/4" in feet
+
+# =============================================================================
+# Logging Utilities
+# =============================================================================
+
+def log_message(message, level="info"):
+    """Log to console and optionally add GH runtime message.
+
+    Args:
+        message: The message to log
+        level: One of "info", "debug", "warning", "error", "remark"
+    """
+    # Always print to console (captured by 'out' parameter and log files)
+    print(f"[{level.upper()}] {message}")
+
+    # Add to GH component UI for warnings and errors
+    if level == "warning":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Warning, message)
+    elif level == "error":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Error, message)
+    elif level == "remark":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Remark, message)
+
+
+def log_debug(message):
+    """Log debug message (console only)."""
+    print(f"[DEBUG] {message}")
+
+
+def log_info(message):
+    """Log info message (console only)."""
+    print(f"[INFO] {message}")
+
+
+def log_warning(message):
+    """Log warning message (console + GH UI)."""
+    log_message(message, "warning")
+
+
+def log_error(message):
+    """Log error message (console + GH UI)."""
+    log_message(message, "error")
+
+# =============================================================================
+# Component Setup
+# =============================================================================
+
+def setup_component():
+    """Initialize and configure the Grasshopper component.
+
+    This function handles:
+    1. Setting component metadata (name, category, etc.)
+    2. Configuring input parameter names, descriptions, and access
+    3. Configuring output parameter names and descriptions
+
+    Note: Output[0] is reserved for GH's internal 'out' - start from Output[1]
+
+    IMPORTANT: Type Hints cannot be set programmatically in Rhino 8.
+    They must be configured via UI: Right-click input -> Type hint -> Select type
+    """
+    # Component metadata
+    ghenv.Component.Name = COMPONENT_NAME
+    ghenv.Component.NickName = COMPONENT_NICKNAME
+    ghenv.Component.Message = COMPONENT_MESSAGE
+    ghenv.Component.Category = COMPONENT_CATEGORY
+    ghenv.Component.SubCategory = COMPONENT_SUBCATEGORY
+
+    # Configure inputs
+    # IMPORTANT: In GHPython, the NickName becomes the Python variable name!
+    # Format: (DisplayName, variable_name, Description, Access)
+    # - Name: Human-readable display name (shown in tooltips)
+    # - NickName: MUST be valid Python identifier - this IS the variable name in code
+    # - Access: item, list, or tree
+    #
+    # NOTE: Type Hints must be set via GH UI (right-click -> Type hint)
+    # They cannot be set programmatically from within the script.
+    inputs = ghenv.Component.Params.Input
+
+    input_config = [
+        # (DisplayName, variable_name, Description, Access)
+        ("Routes JSON", "routes_json", "JSON string with computed routes from OAHS router",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Framing JSON", "framing_json", "JSON string with framing elements from Framing Generator",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Clearance", "clearance", "Pipe clearance in feet (default 0.0208 = 1/4\")",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Run", "run", "Boolean to trigger execution",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+    ]
+
+    for i, (name, nick, desc, access) in enumerate(input_config):
+        if i < inputs.Count:
+            inputs[i].Name = name
+            inputs[i].NickName = nick
+            inputs[i].Description = desc
+            inputs[i].Access = access
+
+    # Configure outputs (start from index 1, as 0 is reserved for 'out')
+    # IMPORTANT: NickName becomes the Python variable name - must match code!
+    outputs = ghenv.Component.Params.Output
+
+    output_config = [
+        # (DisplayName, variable_name, Description) - indices start at 1
+        ("Penetrations JSON", "penetrations_json", "Full penetration specs as JSON string"),
+        ("Allowed Points", "allowed_pts", "Point3d for allowed penetrations (green)"),
+        ("Blocked Points", "blocked_pts", "Point3d for blocked penetrations (red)"),
+        ("Reinforce Points", "reinforce_pts", "Point3d needing reinforcement (orange)"),
+        ("Info", "info", "Diagnostic summary string"),
+    ]
+
+    for i, (name, nick, desc) in enumerate(output_config):
+        idx = i + 1  # Skip Output[0]
+        if idx < outputs.Count:
+            outputs[idx].Name = name
+            outputs[idx].NickName = nick
+            outputs[idx].Description = desc
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def get_factory():
+    """Get RhinoCommonFactory instance for geometry creation.
+
+    Returns:
+        RhinoCommonFactory instance
+
+    Raises:
+        ImportError: If timber_framing_generator is not installed
+    """
+    from src.timber_framing_generator.utils.geometry_factory import get_factory as _get_factory
+    return _get_factory()
+
+
+def validate_inputs(routes_json_input, framing_json_input, run_input):
+    """Validate component inputs.
+
+    Args:
+        routes_json_input: Routes JSON string to validate
+        framing_json_input: Framing JSON string to validate
+        run_input: Run boolean input
+
+    Returns:
+        tuple: (is_valid, error_message)
+    """
+    if not run_input:
+        return False, "Set run=True to execute penetration analysis"
+
+    if not routes_json_input:
+        return False, "Missing routes_json input"
+
+    if not framing_json_input:
+        return False, "Missing framing_json input"
+
+    # Validate routes JSON parsing
+    try:
+        data = json.loads(routes_json_input)
+        if not isinstance(data, dict):
+            return False, "routes_json must be a JSON object"
+        if "routes" not in data:
+            return False, "routes_json missing 'routes' key"
+    except json.JSONDecodeError as e:
+        return False, f"Invalid routes_json: {e}"
+
+    # Validate framing JSON parsing
+    try:
+        framing_data = json.loads(framing_json_input)
+        # Framing JSON can be a list or dict - just check it parses
+    except json.JSONDecodeError as e:
+        return False, f"Invalid framing_json: {e}"
+
+    return True, None
+
+
+def create_status_points(penetrations, factory):
+    """Create Point3d geometry grouped by penetration status.
+
+    Args:
+        penetrations: List of penetration specification dictionaries
+        factory: RhinoCommonFactory instance
+
+    Returns:
+        tuple: (allowed_points, blocked_points, reinforcement_points)
+    """
+    from src.timber_framing_generator.mep.routing.penetration_integration import (
+        extract_penetration_points,
+    )
+
+    # Get coordinate tuples grouped by status
+    allowed_coords, blocked_coords, reinforce_coords = extract_penetration_points(penetrations)
+
+    # Convert to Point3d using factory
+    allowed_pts = []
+    for coord in allowed_coords:
+        try:
+            pt = factory.create_point3d(
+                float(coord[0]),
+                float(coord[1]),
+                float(coord[2])
+            )
+            if pt is not None:
+                allowed_pts.append(pt)
+        except Exception as e:
+            log_debug(f"Error creating allowed point: {e}")
+
+    blocked_pts = []
+    for coord in blocked_coords:
+        try:
+            pt = factory.create_point3d(
+                float(coord[0]),
+                float(coord[1]),
+                float(coord[2])
+            )
+            if pt is not None:
+                blocked_pts.append(pt)
+        except Exception as e:
+            log_debug(f"Error creating blocked point: {e}")
+
+    reinforce_pts = []
+    for coord in reinforce_coords:
+        try:
+            pt = factory.create_point3d(
+                float(coord[0]),
+                float(coord[1]),
+                float(coord[2])
+            )
+            if pt is not None:
+                reinforce_pts.append(pt)
+        except Exception as e:
+            log_debug(f"Error creating reinforcement point: {e}")
+
+    return allowed_pts, blocked_pts, reinforce_pts
+
+
+def process_penetrations(routes_json_str, framing_json_str, clearance_value):
+    """Process route data and generate penetration specifications.
+
+    Args:
+        routes_json_str: JSON string with routes data
+        framing_json_str: JSON string with framing data
+        clearance_value: Pipe clearance in feet
+
+    Returns:
+        tuple: (penetrations_json, allowed_pts, blocked_pts, reinforce_pts, info_string)
+    """
+    log_info("Starting penetration analysis")
+
+    # Import penetration integration functions
+    try:
+        from src.timber_framing_generator.mep.routing.penetration_integration import (
+            integrate_routes_to_penetrations,
+            penetrations_to_json,
+            get_penetration_info_string,
+        )
+    except ImportError as e:
+        log_error(f"Could not import penetration_integration: {e}")
+        return "", [], [], [], f"Import error: {e}"
+
+    # Get geometry factory
+    try:
+        factory = get_factory()
+    except ImportError as e:
+        log_error(f"Could not import geometry factory: {e}")
+        return "", [], [], [], f"Import error: {e}"
+
+    # Run penetration integration
+    try:
+        result = integrate_routes_to_penetrations(
+            routes_json=routes_json_str,
+            framing_json=framing_json_str,
+            clearance=clearance_value,
+        )
+    except ValueError as e:
+        log_error(f"Penetration analysis failed: {e}")
+        return "", [], [], [], f"Analysis error: {e}"
+    except Exception as e:
+        log_error(f"Unexpected error in penetration analysis: {e}")
+        log_debug(traceback.format_exc())
+        return "", [], [], [], f"Unexpected error: {e}"
+
+    # Convert result to JSON
+    penetrations_json_out = penetrations_to_json(result)
+
+    # Get info string
+    info_string = get_penetration_info_string(result)
+
+    # Extract penetrations for point creation
+    penetrations = result.get("penetrations", [])
+
+    # Create status-grouped points
+    allowed_pts, blocked_pts, reinforce_pts = create_status_points(penetrations, factory)
+
+    log_info(f"Penetration analysis complete: {len(allowed_pts)} allowed, {len(blocked_pts)} blocked, {len(reinforce_pts)} need reinforcement")
+
+    return penetrations_json_out, allowed_pts, blocked_pts, reinforce_pts, info_string
+
+# =============================================================================
+# Main Function
+# =============================================================================
+
+def main():
+    """Main entry point for the component.
+
+    Coordinates the overall workflow:
+    1. Setup component metadata
+    2. Validate inputs
+    3. Process penetration analysis
+    4. Return results
+
+    Returns:
+        tuple: (penetrations_json, allowed_pts, blocked_pts, reinforce_pts, info)
+               or empty outputs on failure
+    """
+    # Setup component
+    setup_component()
+
+    # Initialize empty outputs
+    empty_json = ""
+    empty_pts = []
+
+    try:
+        # Get inputs (these come from GH component inputs)
+        # Use globals() to check if variables are defined
+        routes_json_input = routes_json if 'routes_json' in dir() else None
+        framing_json_input = framing_json if 'framing_json' in dir() else None
+        clearance_input = clearance if 'clearance' in dir() else None
+        run_input = run if 'run' in dir() else False
+
+        # Handle None/unset clearance with default
+        if clearance_input is None:
+            clearance_input = DEFAULT_CLEARANCE
+
+        # Validate inputs
+        is_valid, error_msg = validate_inputs(routes_json_input, framing_json_input, run_input)
+        if not is_valid:
+            if error_msg and "run=True" not in error_msg:
+                log_warning(error_msg)
+            return empty_json, empty_pts, empty_pts, empty_pts, error_msg or "Disabled"
+
+        # Process penetrations
+        penetrations_json_out, allowed_pts, blocked_pts, reinforce_pts, info_string = process_penetrations(
+            routes_json_input,
+            framing_json_input,
+            clearance_input
+        )
+
+        return penetrations_json_out, allowed_pts, blocked_pts, reinforce_pts, info_string
+
+    except Exception as e:
+        log_error(f"Unexpected error: {str(e)}")
+        log_debug(traceback.format_exc())
+        return empty_json, empty_pts, empty_pts, empty_pts, f"Error: {str(e)}"
+
+# =============================================================================
+# Execution
+# =============================================================================
+
+if __name__ == "__main__":
+    # Execute main and assign to output variables
+    # These variable names must match your GH component outputs
+    penetrations_json, allowed_pts, blocked_pts, reinforce_pts, info = main()

--- a/src/timber_framing_generator/mep/routing/penetration_integration.py
+++ b/src/timber_framing_generator/mep/routing/penetration_integration.py
@@ -1,0 +1,356 @@
+# File: src/timber_framing_generator/mep/routing/penetration_integration.py
+"""
+Penetration integration for MEP routing.
+
+Bridges OAHS route output (routes_json) to existing penetration generation
+logic. Converts route JSON to MEPRoute objects and calls the established
+penetration rules for code-compliant penetration specifications.
+
+Key Features:
+1. JSON-to-MEPRoute conversion
+2. Framing element parsing
+3. Penetration generation with code compliance
+4. Reinforcement flagging
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, List, Any, Optional, Tuple
+
+from src.timber_framing_generator.core.mep_system import MEPRoute, MEPDomain
+from src.timber_framing_generator.mep.plumbing.penetration_rules import (
+    generate_plumbing_penetrations,
+    MAX_PENETRATION_RATIO,
+    REINFORCEMENT_THRESHOLD,
+    PLUMBING_PENETRATION_CLEARANCE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# JSON Parsing
+# ============================================================================
+
+def _parse_routes_json(routes_json_str: str) -> List[Dict[str, Any]]:
+    """
+    Parse routes from JSON string.
+
+    Args:
+        routes_json_str: JSON string with routes data
+
+    Returns:
+        List of route dictionaries
+
+    Raises:
+        ValueError: If JSON is invalid or missing 'routes' key
+    """
+    try:
+        data = json.loads(routes_json_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid routes JSON: {e}")
+
+    if not isinstance(data, dict):
+        raise ValueError("Routes JSON must be an object")
+
+    if "routes" not in data:
+        raise ValueError("Routes JSON missing 'routes' key")
+
+    return data.get("routes", [])
+
+
+def _parse_framing_json(framing_json_str: str) -> List[Dict[str, Any]]:
+    """
+    Parse framing elements from JSON string.
+
+    Args:
+        framing_json_str: JSON string with framing data
+
+    Returns:
+        List of framing element dictionaries
+
+    Raises:
+        ValueError: If JSON is invalid
+    """
+    try:
+        data = json.loads(framing_json_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid framing JSON: {e}")
+
+    # Support multiple JSON formats
+    if isinstance(data, list):
+        return data
+
+    if isinstance(data, dict):
+        # Try common keys
+        for key in ["elements", "framing_elements", "framing", "walls"]:
+            if key in data:
+                elements = data[key]
+                if isinstance(elements, list):
+                    return elements
+
+        # Flatten nested wall structures
+        if "walls" in data:
+            all_elements = []
+            for wall in data["walls"]:
+                if isinstance(wall, dict) and "elements" in wall:
+                    all_elements.extend(wall["elements"])
+            if all_elements:
+                return all_elements
+
+    return []
+
+
+# ============================================================================
+# Route Conversion
+# ============================================================================
+
+def _system_type_to_domain(system_type: str) -> MEPDomain:
+    """
+    Convert system type string to MEPDomain enum.
+
+    Args:
+        system_type: System type string (e.g., "sanitary_drain", "dhw")
+
+    Returns:
+        MEPDomain enum value
+    """
+    system_lower = system_type.lower() if system_type else ""
+
+    if any(s in system_lower for s in ["sanitary", "drain", "vent", "dhw", "dcw", "water"]):
+        return MEPDomain.PLUMBING
+    elif any(s in system_lower for s in ["hvac", "duct", "supply", "return"]):
+        return MEPDomain.HVAC
+    elif any(s in system_lower for s in ["power", "electrical", "data", "lighting"]):
+        return MEPDomain.ELECTRICAL
+    else:
+        return MEPDomain.PLUMBING  # Default
+
+
+def _route_dict_to_mep_route(route_dict: Dict[str, Any]) -> MEPRoute:
+    """
+    Convert route dictionary to MEPRoute object.
+
+    Args:
+        route_dict: Route dictionary from routes_json
+
+    Returns:
+        MEPRoute object
+    """
+    route_id = route_dict.get("route_id", route_dict.get("id", "unknown"))
+    system_type = route_dict.get("system_type", "unknown")
+    domain = _system_type_to_domain(system_type)
+
+    # Extract path points from segments
+    path_points = []
+    segments = route_dict.get("segments", [])
+
+    for i, seg in enumerate(segments):
+        start = seg.get("start", [])
+        end = seg.get("end", [])
+
+        # Add start point (avoid duplicates)
+        if start and len(start) >= 3:
+            point = (float(start[0]), float(start[1]), float(start[2]))
+            if not path_points or path_points[-1] != point:
+                path_points.append(point)
+
+        # Add end point
+        if end and len(end) >= 3:
+            point = (float(end[0]), float(end[1]), float(end[2]))
+            if not path_points or path_points[-1] != point:
+                path_points.append(point)
+
+    # Get pipe size (default to 1" if not specified)
+    pipe_size = route_dict.get("pipe_size", 0.0833)  # 1" in feet
+    if isinstance(pipe_size, str):
+        # Try to parse size string
+        try:
+            pipe_size = float(pipe_size)
+        except ValueError:
+            pipe_size = 0.0833
+
+    return MEPRoute(
+        id=route_id,
+        domain=domain,
+        system_type=system_type,
+        path_points=path_points,
+        start_connector_id=route_dict.get("start_connector_id", ""),
+        end_point_type=route_dict.get("end_point_type", "target"),
+        pipe_size=pipe_size,
+        end_point=path_points[-1] if path_points else None,
+        penetrations=[],
+    )
+
+
+def _convert_routes(route_dicts: List[Dict[str, Any]]) -> List[MEPRoute]:
+    """
+    Convert list of route dictionaries to MEPRoute objects.
+
+    Args:
+        route_dicts: List of route dictionaries from routes_json
+
+    Returns:
+        List of MEPRoute objects
+    """
+    routes = []
+
+    for route_dict in route_dicts:
+        try:
+            route = _route_dict_to_mep_route(route_dict)
+            if route.path_points:  # Only add routes with valid paths
+                routes.append(route)
+        except Exception as e:
+            logger.warning(f"Failed to convert route {route_dict.get('route_id', 'unknown')}: {e}")
+
+    return routes
+
+
+# ============================================================================
+# Main Integration Function
+# ============================================================================
+
+def integrate_routes_to_penetrations(
+    routes_json: str,
+    framing_json: str,
+    clearance: Optional[float] = None,
+) -> Dict[str, Any]:
+    """
+    Convert OAHS routes to penetration specifications.
+
+    Bridges the JSON-based OAHS routing output to the existing penetration
+    generation logic, producing validated penetration specs with code
+    compliance information.
+
+    Args:
+        routes_json: JSON string from gh_mep_router (routes_json output)
+        framing_json: JSON string from gh_framing_generator (framing_json output)
+        clearance: Optional custom pipe clearance in feet (default 1/4")
+
+    Returns:
+        Dictionary with:
+        - penetrations: List of penetration specifications
+        - summary: Statistics about allowed/blocked/reinforcement needed
+
+    Raises:
+        ValueError: If JSON inputs are invalid
+    """
+    logger.info("Starting route-to-penetration integration")
+
+    # Parse inputs
+    route_dicts = _parse_routes_json(routes_json)
+    framing_elements = _parse_framing_json(framing_json)
+
+    logger.info(f"Parsed {len(route_dicts)} routes and {len(framing_elements)} framing elements")
+
+    # Convert routes to MEPRoute objects
+    routes = _convert_routes(route_dicts)
+    logger.info(f"Converted {len(routes)} valid routes")
+
+    # Generate penetrations using existing logic
+    penetrations = generate_plumbing_penetrations(routes, framing_elements)
+
+    # Build summary statistics
+    total = len(penetrations)
+    allowed = sum(1 for p in penetrations if p.get("is_allowed", False))
+    blocked = total - allowed
+    reinforcement_needed = sum(1 for p in penetrations if p.get("reinforcement_required", False))
+
+    summary = {
+        "total": total,
+        "allowed": allowed,
+        "blocked": blocked,
+        "reinforcement_required": reinforcement_needed,
+        "routes_processed": len(routes),
+        "framing_elements": len(framing_elements),
+    }
+
+    logger.info(f"Generated {total} penetrations: {allowed} allowed, {blocked} blocked, {reinforcement_needed} need reinforcement")
+
+    return {
+        "penetrations": penetrations,
+        "summary": summary,
+    }
+
+
+def penetrations_to_json(result: Dict[str, Any]) -> str:
+    """
+    Convert penetration result to JSON string.
+
+    Args:
+        result: Result dictionary from integrate_routes_to_penetrations
+
+    Returns:
+        JSON string
+    """
+    return json.dumps(result, indent=2)
+
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+def extract_penetration_points(
+    penetrations: List[Dict[str, Any]]
+) -> Tuple[List[Tuple[float, float, float]], List[Tuple[float, float, float]], List[Tuple[float, float, float]]]:
+    """
+    Extract points from penetrations grouped by status.
+
+    Args:
+        penetrations: List of penetration specifications
+
+    Returns:
+        Tuple of (allowed_points, blocked_points, reinforcement_points)
+    """
+    allowed = []
+    blocked = []
+    reinforcement = []
+
+    for pen in penetrations:
+        loc = pen.get("location", {})
+        point = (
+            float(loc.get("x", 0)),
+            float(loc.get("y", 0)),
+            float(loc.get("z", 0))
+        )
+
+        if not pen.get("is_allowed", False):
+            blocked.append(point)
+        elif pen.get("reinforcement_required", False):
+            reinforcement.append(point)
+        else:
+            allowed.append(point)
+
+    return allowed, blocked, reinforcement
+
+
+def get_penetration_info_string(result: Dict[str, Any]) -> str:
+    """
+    Generate a human-readable info string from penetration results.
+
+    Args:
+        result: Result dictionary from integrate_routes_to_penetrations
+
+    Returns:
+        Formatted info string
+    """
+    summary = result.get("summary", {})
+
+    lines = [
+        "Penetration Analysis Results",
+        "=" * 30,
+        f"Routes processed: {summary.get('routes_processed', 0)}",
+        f"Framing elements: {summary.get('framing_elements', 0)}",
+        "",
+        f"Total penetrations: {summary.get('total', 0)}",
+        f"  Allowed: {summary.get('allowed', 0)}",
+        f"  Blocked: {summary.get('blocked', 0)}",
+        f"  Reinforcement required: {summary.get('reinforcement_required', 0)}",
+        "",
+        f"Code limit: {MAX_PENETRATION_RATIO * 100:.0f}% of member depth",
+        f"Reinforcement threshold: {REINFORCEMENT_THRESHOLD * 100:.0f}% of member depth",
+    ]
+
+    return "\n".join(lines)

--- a/tests/mep/routing/test_penetration_integration.py
+++ b/tests/mep/routing/test_penetration_integration.py
@@ -1,0 +1,456 @@
+# File: tests/mep/routing/test_penetration_integration.py
+"""
+Tests for MEP routing penetration integration.
+
+Tests the bridge module that connects OAHS routing output to
+existing penetration generation logic.
+"""
+
+import pytest
+import json
+
+from src.timber_framing_generator.mep.routing.penetration_integration import (
+    integrate_routes_to_penetrations,
+    penetrations_to_json,
+    extract_penetration_points,
+    get_penetration_info_string,
+    _parse_routes_json,
+    _parse_framing_json,
+    _convert_routes,
+    _route_dict_to_mep_route,
+    _system_type_to_domain,
+)
+from src.timber_framing_generator.core.mep_system import MEPDomain
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def sample_routes_json():
+    """Sample routes JSON from OAHS router."""
+    return json.dumps({
+        "routes": [
+            {
+                "route_id": "route_001",
+                "system_type": "sanitary_drain",
+                "pipe_size": 0.1583,  # 1.5" pipe
+                "segments": [
+                    {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                    {"start": [5.0, 0.0, 4.0], "end": [10.0, 0.0, 4.0]},
+                ],
+                "junctions": [[5.0, 0.0, 4.0]],
+            },
+            {
+                "route_id": "route_002",
+                "system_type": "dhw",
+                "pipe_size": 0.0729,  # 1/2" pipe
+                "segments": [
+                    {"start": [0.0, 5.0, 6.0], "end": [8.0, 5.0, 6.0]},
+                ],
+            },
+        ]
+    })
+
+
+@pytest.fixture
+def sample_framing_json():
+    """Sample framing JSON from framing generator."""
+    return json.dumps({
+        "elements": [
+            {
+                "id": "stud_001",
+                "element_type": "stud",
+                "centerline": {
+                    "start": {"x": 3.0, "y": 0.0, "z": 0.0},
+                    "end": {"x": 3.0, "y": 0.0, "z": 8.0},
+                },
+                "profile": {
+                    "width": 0.125,  # 1.5"
+                    "depth": 0.292,  # 3.5"
+                },
+            },
+            {
+                "id": "stud_002",
+                "element_type": "stud",
+                "centerline": {
+                    "start": {"x": 6.0, "y": 0.0, "z": 0.0},
+                    "end": {"x": 6.0, "y": 0.0, "z": 8.0},
+                },
+                "profile": {
+                    "width": 0.125,
+                    "depth": 0.292,
+                },
+            },
+            {
+                "id": "header_001",
+                "element_type": "header",  # Not a vertical element - should be filtered
+                "centerline": {
+                    "start": {"x": 0.0, "y": 0.0, "z": 7.0},
+                    "end": {"x": 10.0, "y": 0.0, "z": 7.0},
+                },
+                "profile": {
+                    "width": 0.292,
+                    "depth": 0.125,
+                },
+            },
+        ]
+    })
+
+
+@pytest.fixture
+def empty_routes_json():
+    """Empty routes JSON."""
+    return json.dumps({"routes": []})
+
+
+@pytest.fixture
+def empty_framing_json():
+    """Empty framing JSON."""
+    return json.dumps({"elements": []})
+
+
+# ============================================================================
+# JSON Parsing Tests
+# ============================================================================
+
+class TestParseRoutesJson:
+    """Tests for routes JSON parsing."""
+
+    def test_parse_valid_routes(self, sample_routes_json):
+        """Parse valid routes JSON."""
+        routes = _parse_routes_json(sample_routes_json)
+
+        assert len(routes) == 2
+        assert routes[0]["route_id"] == "route_001"
+        assert routes[1]["route_id"] == "route_002"
+
+    def test_parse_empty_routes(self, empty_routes_json):
+        """Parse empty routes JSON returns empty list."""
+        routes = _parse_routes_json(empty_routes_json)
+
+        assert routes == []
+
+    def test_parse_invalid_json_raises(self):
+        """Invalid JSON raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid routes JSON"):
+            _parse_routes_json("not valid json")
+
+    def test_parse_missing_routes_key_raises(self):
+        """JSON without 'routes' key raises ValueError."""
+        with pytest.raises(ValueError, match="missing 'routes' key"):
+            _parse_routes_json('{"other": []}')
+
+    def test_parse_non_object_raises(self):
+        """Non-object JSON raises ValueError."""
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_routes_json('["array", "not", "object"]')
+
+
+class TestParseFramingJson:
+    """Tests for framing JSON parsing."""
+
+    def test_parse_elements_format(self, sample_framing_json):
+        """Parse framing JSON with 'elements' key."""
+        elements = _parse_framing_json(sample_framing_json)
+
+        assert len(elements) == 3
+
+    def test_parse_list_format(self):
+        """Parse framing JSON as direct list."""
+        framing_json = json.dumps([
+            {"id": "stud_001", "element_type": "stud"},
+        ])
+        elements = _parse_framing_json(framing_json)
+
+        assert len(elements) == 1
+
+    def test_parse_invalid_json_raises(self):
+        """Invalid JSON raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid framing JSON"):
+            _parse_framing_json("not valid json")
+
+    def test_parse_empty_returns_empty(self, empty_framing_json):
+        """Empty elements returns empty list."""
+        elements = _parse_framing_json(empty_framing_json)
+
+        assert elements == []
+
+
+# ============================================================================
+# Route Conversion Tests
+# ============================================================================
+
+class TestSystemTypeToDomain:
+    """Tests for system type to domain conversion."""
+
+    def test_sanitary_to_plumbing(self):
+        """Sanitary types map to plumbing domain."""
+        assert _system_type_to_domain("sanitary_drain") == MEPDomain.PLUMBING
+        assert _system_type_to_domain("sanitary_vent") == MEPDomain.PLUMBING
+
+    def test_water_to_plumbing(self):
+        """Water types map to plumbing domain."""
+        assert _system_type_to_domain("dhw") == MEPDomain.PLUMBING
+        assert _system_type_to_domain("dcw") == MEPDomain.PLUMBING
+
+    def test_hvac_to_hvac(self):
+        """HVAC types map to HVAC domain."""
+        assert _system_type_to_domain("hvac_supply") == MEPDomain.HVAC
+        assert _system_type_to_domain("duct_supply") == MEPDomain.HVAC
+
+    def test_electrical_to_electrical(self):
+        """Electrical types map to electrical domain."""
+        assert _system_type_to_domain("power") == MEPDomain.ELECTRICAL
+        assert _system_type_to_domain("lighting") == MEPDomain.ELECTRICAL
+        assert _system_type_to_domain("data") == MEPDomain.ELECTRICAL
+
+    def test_unknown_defaults_to_plumbing(self):
+        """Unknown types default to plumbing."""
+        assert _system_type_to_domain("unknown") == MEPDomain.PLUMBING
+        assert _system_type_to_domain("") == MEPDomain.PLUMBING
+
+
+class TestRouteConversion:
+    """Tests for route dictionary to MEPRoute conversion."""
+
+    def test_convert_basic_route(self):
+        """Convert basic route dictionary to MEPRoute."""
+        route_dict = {
+            "route_id": "test_route",
+            "system_type": "sanitary_drain",
+            "pipe_size": 0.1583,
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+            ],
+        }
+        route = _route_dict_to_mep_route(route_dict)
+
+        assert route.id == "test_route"
+        assert route.system_type == "sanitary_drain"
+        assert route.pipe_size == 0.1583
+        assert len(route.path_points) == 2
+
+    def test_convert_multi_segment_route(self):
+        """Convert route with multiple segments."""
+        route_dict = {
+            "route_id": "multi_seg",
+            "system_type": "dhw",
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                {"start": [5.0, 0.0, 4.0], "end": [10.0, 0.0, 4.0]},
+                {"start": [10.0, 0.0, 4.0], "end": [10.0, 5.0, 4.0]},
+            ],
+        }
+        route = _route_dict_to_mep_route(route_dict)
+
+        # Should have 4 unique points (no duplicates at junctions)
+        assert len(route.path_points) == 4
+
+    def test_convert_route_default_pipe_size(self):
+        """Route without pipe_size gets default."""
+        route_dict = {
+            "route_id": "no_size",
+            "system_type": "dcw",
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+            ],
+        }
+        route = _route_dict_to_mep_route(route_dict)
+
+        assert route.pipe_size == 0.0833  # Default 1"
+
+    def test_convert_routes_filters_empty(self):
+        """Convert routes filters out routes with no valid paths."""
+        route_dicts = [
+            {
+                "route_id": "valid",
+                "system_type": "sanitary_drain",
+                "segments": [
+                    {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                ],
+            },
+            {
+                "route_id": "empty",
+                "system_type": "dhw",
+                "segments": [],  # No segments
+            },
+        ]
+        routes = _convert_routes(route_dicts)
+
+        assert len(routes) == 1
+        assert routes[0].id == "valid"
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+class TestIntegrateRoutesToPenetrations:
+    """Tests for full route-to-penetration integration."""
+
+    def test_basic_integration(self, sample_routes_json, sample_framing_json):
+        """Basic integration produces penetrations."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            sample_framing_json
+        )
+
+        assert "penetrations" in result
+        assert "summary" in result
+
+    def test_summary_statistics(self, sample_routes_json, sample_framing_json):
+        """Summary contains expected statistics."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            sample_framing_json
+        )
+
+        summary = result["summary"]
+        assert "total" in summary
+        assert "allowed" in summary
+        assert "blocked" in summary
+        assert "reinforcement_required" in summary
+        assert "routes_processed" in summary
+        assert summary["routes_processed"] == 2
+
+    def test_empty_routes_returns_empty(self, empty_routes_json, sample_framing_json):
+        """Empty routes returns empty penetrations."""
+        result = integrate_routes_to_penetrations(
+            empty_routes_json,
+            sample_framing_json
+        )
+
+        assert result["penetrations"] == []
+        assert result["summary"]["total"] == 0
+
+    def test_empty_framing_returns_empty(self, sample_routes_json, empty_framing_json):
+        """Empty framing returns empty penetrations."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            empty_framing_json
+        )
+
+        assert result["penetrations"] == []
+        assert result["summary"]["total"] == 0
+
+    def test_invalid_routes_raises(self, sample_framing_json):
+        """Invalid routes JSON raises ValueError."""
+        with pytest.raises(ValueError):
+            integrate_routes_to_penetrations(
+                "invalid json",
+                sample_framing_json
+            )
+
+    def test_invalid_framing_raises(self, sample_routes_json):
+        """Invalid framing JSON raises ValueError."""
+        with pytest.raises(ValueError):
+            integrate_routes_to_penetrations(
+                sample_routes_json,
+                "invalid json"
+            )
+
+
+class TestPenetrationsToJson:
+    """Tests for JSON serialization."""
+
+    def test_serialize_result(self, sample_routes_json, sample_framing_json):
+        """Serialize penetration result to JSON."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            sample_framing_json
+        )
+        json_str = penetrations_to_json(result)
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert "penetrations" in parsed
+        assert "summary" in parsed
+
+
+# ============================================================================
+# Utility Tests
+# ============================================================================
+
+class TestExtractPenetrationPoints:
+    """Tests for point extraction by status."""
+
+    def test_extract_allowed_points(self):
+        """Extract allowed penetration points."""
+        penetrations = [
+            {"location": {"x": 1.0, "y": 2.0, "z": 3.0}, "is_allowed": True, "reinforcement_required": False},
+        ]
+        allowed, blocked, reinforce = extract_penetration_points(penetrations)
+
+        assert len(allowed) == 1
+        assert len(blocked) == 0
+        assert len(reinforce) == 0
+        assert allowed[0] == (1.0, 2.0, 3.0)
+
+    def test_extract_blocked_points(self):
+        """Extract blocked penetration points."""
+        penetrations = [
+            {"location": {"x": 4.0, "y": 5.0, "z": 6.0}, "is_allowed": False, "reinforcement_required": False},
+        ]
+        allowed, blocked, reinforce = extract_penetration_points(penetrations)
+
+        assert len(allowed) == 0
+        assert len(blocked) == 1
+        assert len(reinforce) == 0
+        assert blocked[0] == (4.0, 5.0, 6.0)
+
+    def test_extract_reinforcement_points(self):
+        """Extract reinforcement-required points."""
+        penetrations = [
+            {"location": {"x": 7.0, "y": 8.0, "z": 9.0}, "is_allowed": True, "reinforcement_required": True},
+        ]
+        allowed, blocked, reinforce = extract_penetration_points(penetrations)
+
+        assert len(allowed) == 0
+        assert len(blocked) == 0
+        assert len(reinforce) == 1
+        assert reinforce[0] == (7.0, 8.0, 9.0)
+
+    def test_extract_mixed_points(self):
+        """Extract mixed penetration status."""
+        penetrations = [
+            {"location": {"x": 1.0, "y": 0.0, "z": 0.0}, "is_allowed": True, "reinforcement_required": False},
+            {"location": {"x": 2.0, "y": 0.0, "z": 0.0}, "is_allowed": False, "reinforcement_required": False},
+            {"location": {"x": 3.0, "y": 0.0, "z": 0.0}, "is_allowed": True, "reinforcement_required": True},
+        ]
+        allowed, blocked, reinforce = extract_penetration_points(penetrations)
+
+        assert len(allowed) == 1
+        assert len(blocked) == 1
+        assert len(reinforce) == 1
+
+
+class TestGetPenetrationInfoString:
+    """Tests for info string generation."""
+
+    def test_info_string_contains_summary(self, sample_routes_json, sample_framing_json):
+        """Info string contains summary statistics."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            sample_framing_json
+        )
+        info = get_penetration_info_string(result)
+
+        assert "Penetration Analysis Results" in info
+        assert "Routes processed" in info
+        assert "Total penetrations" in info
+        assert "Allowed" in info
+        assert "Blocked" in info
+        assert "Reinforcement required" in info
+
+    def test_info_string_contains_code_limits(self, sample_routes_json, sample_framing_json):
+        """Info string contains code limit information."""
+        result = integrate_routes_to_penetrations(
+            sample_routes_json,
+            sample_framing_json
+        )
+        info = get_penetration_info_string(result)
+
+        assert "40%" in info  # MAX_PENETRATION_RATIO
+        assert "33%" in info  # REINFORCEMENT_THRESHOLD


### PR DESCRIPTION
## Summary
- Bridge OAHS routes to penetration specifications
- Validate against code limits (40% max penetration ratio)
- Flag penetrations requiring structural reinforcement (>33%)
- GHPython component with color-coded status points

## Changes
- Add `src/timber_framing_generator/mep/routing/penetration_integration.py` - Route-to-penetration bridge
- Add `scripts/gh_mep_penetration_generator.py` - GHPython visualization component
- Add `tests/mep/routing/test_penetration_integration.py` - 31 tests
- Add `PRPs/PRP-020--mep-routing-penetrations.md` - Specification

## Test plan
- [x] 31 unit tests passing
- [ ] Load component in Grasshopper
- [ ] Connect routes_json and framing_json inputs
- [ ] Verify allowed/blocked/reinforce points display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)