### PR TITLE
Phase 11: Pipe/Conduit Creator Component

### DIFF
--- a/PRPs/PRP-021--mep-routing-pipe-creator.md
+++ b/PRPs/PRP-021--mep-routing-pipe-creator.md
@@ -1,0 +1,156 @@
+# PRP-021: MEP Pipe/Conduit Creator Component
+
+## Overview
+
+**Feature**: Pipe/Conduit Creator for Rhino.Inside.Revit Integration
+**Branch**: `feature/mep-routing-phase11-creator`
+**Issue**: #33 - MEP Routing Solver: OAHS Implementation Plan (Phase 11)
+
+## Problem Statement
+
+Routes computed by OAHS need to become Revit pipes/conduits:
+
+1. **System Mapping**: Map route system types to Revit pipe types
+2. **Pipe Creation**: Generate Revit pipes from route segments
+3. **Fitting Insertion**: Add fittings at direction changes
+4. **Junction Fittings**: Add T-fittings at merge points
+
+## Solution Design
+
+### 1. Revit Pipe Type Mapping
+
+**File**: `src/timber_framing_generator/mep/routing/revit_pipe_mapper.py`
+
+```python
+# System type to Revit pipe type family mapping
+REVIT_PIPE_TYPES = {
+    "sanitary_drain": {
+        "category": "Pipe",
+        "system_type": "Sanitary",
+        "pipe_type": "Cast Iron - No Hub"
+    },
+    "sanitary_vent": {
+        "category": "Pipe",
+        "system_type": "Sanitary",
+        "pipe_type": "PVC - Schedule 40"
+    },
+    "dhw": {
+        "category": "Pipe",
+        "system_type": "Domestic Hot Water",
+        "pipe_type": "Copper Type L"
+    },
+    "dcw": {
+        "category": "Pipe",
+        "system_type": "Domestic Cold Water",
+        "pipe_type": "PEX"
+    },
+    "power": {
+        "category": "Conduit",
+        "system_type": "Power",
+        "conduit_type": "EMT"
+    },
+    "data": {
+        "category": "Conduit",
+        "system_type": "Communications",
+        "conduit_type": "EMT"
+    },
+}
+```
+
+### 2. GHPython Component: gh_mep_pipe_creator.py
+
+**Inputs**:
+- `routes_json`: From MEP Router
+- `doc`: Revit document (from RiR)
+- `pipe_type_overrides`: Optional JSON for custom type mappings
+- `create_fittings`: Boolean to enable fitting creation
+- `run`: Boolean trigger
+
+**Outputs**:
+- `pipe_specs_json`: Pipe specifications for Revit creation
+- `fitting_specs_json`: Fitting specifications
+- `curves`: Visualization curves for review
+- `info`: Diagnostic summary
+
+### 3. Pipe Specification Schema
+
+```json
+{
+  "pipes": [
+    {
+      "id": "pipe_001",
+      "route_id": "route_001",
+      "system_type": "sanitary_drain",
+      "start_point": [0.0, 0.0, 4.0],
+      "end_point": [5.0, 0.0, 4.0],
+      "diameter": 0.125,
+      "revit_config": {
+        "system_type": "Sanitary",
+        "pipe_type": "Cast Iron - No Hub",
+        "level": "Level 1"
+      }
+    }
+  ],
+  "fittings": [
+    {
+      "id": "fitting_001",
+      "type": "elbow_90",
+      "location": [5.0, 0.0, 4.0],
+      "connected_pipes": ["pipe_001", "pipe_002"],
+      "angle": 90
+    }
+  ]
+}
+```
+
+### 4. Fitting Detection Logic
+
+**Direction Changes**:
+- Calculate angle between consecutive segments
+- 85-95°: Insert 90° elbow
+- 40-50°: Insert 45° elbow
+- Other angles: Flag for manual review
+
+**Junction Points**:
+- Detect where multiple routes merge
+- Insert tee fitting
+- Determine main vs branch connections
+
+## Implementation Steps
+
+### Step 1: Pipe Mapper Module
+- System type to Revit type mapping
+- Default and override configuration
+- Size mapping (nominal to actual)
+
+### Step 2: Fitting Detector
+- Angle calculation between segments
+- Junction detection
+- Fitting type selection
+
+### Step 3: GHPython Component
+- Parse routes_json
+- Generate pipe specs with Revit config
+- Generate fitting specs
+- Output visualization curves
+
+### Step 4: Tests
+- Pipe type mapping tests
+- Fitting detection tests
+- JSON serialization tests
+
+## Exit Criteria
+
+- [ ] revit_pipe_mapper.py module created
+- [ ] gh_mep_pipe_creator.py component created
+- [ ] System types map to correct Revit pipe types
+- [ ] Fittings detected at direction changes
+- [ ] T-fittings detected at junctions
+- [ ] Tests passing
+- [ ] Component documented
+
+## Notes
+
+The actual Revit pipe creation via API will be handled by a downstream
+component using Rhino.Inside.Revit's Python API. This component produces
+the specifications needed for that creation step.

--- a/scripts/gh_mep_pipe_creator.py
+++ b/scripts/gh_mep_pipe_creator.py
@@ -1,0 +1,533 @@
+# File: scripts/gh_mep_pipe_creator.py
+"""MEP Pipe Creator for Grasshopper.
+
+Converts MEP route JSON from the OAHS routing algorithm into pipe and conduit
+specifications for Revit creation via Rhino.Inside.Revit. This component bridges
+the routing results to Revit element creation, generating both pipe segments
+and fitting specifications.
+
+Key Features:
+1. Route to Pipe Conversion
+   - Converts route segments to pipe specifications
+   - Maps system types to Revit pipe/conduit types
+   - Includes nominal size and diameter information
+
+2. Fitting Detection
+   - Detects direction changes for elbow fittings
+   - Identifies 90-degree and 45-degree bends
+   - Generates fitting specifications with angles
+
+3. Type Override Support
+   - Custom pipe type mappings via JSON input
+   - Override default Revit type assignments
+   - Per-system-type configuration
+
+4. Visual Output
+   - LineCurve geometry for pipe path visualization
+   - Point3d markers at fitting locations
+   - DataTree output for per-route organization
+
+Environment:
+    Rhino 8
+    Grasshopper
+    Python component (CPython 3)
+
+Dependencies:
+    - Rhino.Geometry: Core geometry creation (via RhinoCommonFactory)
+    - Grasshopper: DataTree and component framework
+    - json: Parsing route and override data
+    - timber_framing_generator: RhinoCommonFactory and revit_pipe_mapper module
+
+Performance Considerations:
+    - Linear scaling with number of routes and segments
+    - Fitting detection adds minimal overhead per route
+    - For >100 routes, consider filtering by system type first
+
+Usage:
+    1. Connect routes_json from MEP Router component
+    2. Optionally provide type_overrides_json for custom mappings
+    3. Toggle create_fittings to enable/disable fitting detection
+    4. Set run=True to execute pipe creation
+    5. Connect pipe_specs_json to Revit creation component
+
+Input Requirements:
+    Routes JSON (routes_json) - str:
+        JSON string containing computed routes from OAHS router.
+        Must have "routes" array with route objects containing
+        "segments" (with start/end coords) and "system_type".
+        Required: Yes
+        Access: Item
+
+    Type Overrides JSON (type_overrides_json) - str:
+        Optional JSON string with custom pipe type mappings.
+        Format: {"system_type": {"pipe_type": "...", ...}}
+        Required: No (empty string uses defaults)
+        Access: Item
+
+    Create Fittings (create_fittings) - bool:
+        Enable fitting detection at direction changes.
+        Required: No (defaults to True)
+        Access: Item
+
+    Run (run) - bool:
+        Trigger to execute pipe creation. Set True to process.
+        Required: Yes
+        Access: Item
+
+Outputs:
+    Pipe Specs JSON (pipe_specs_json) - str:
+        JSON string with pipe specifications for Revit creation.
+        Contains array of pipe objects with endpoints, diameter,
+        system type, and Revit configuration.
+
+    Fitting Specs JSON (fitting_specs_json) - str:
+        JSON string with fitting specifications.
+        Contains array of fitting objects with type, location,
+        angle, and connected pipe IDs.
+
+    Curves (curves) - DataTree[Curve]:
+        LineCurve visualization of pipe paths.
+        One branch per route for selection/filtering.
+
+    Fitting Points (fitting_pts) - List[Point3d]:
+        Point3d markers at fitting locations.
+        Use for visualization of direction changes.
+
+    Info (info) - str:
+        Diagnostic summary string with pipe/fitting counts.
+
+Technical Details:
+    - Uses RhinoCommonFactory for all geometry creation
+    - Pipe specs include Revit type mapping from revit_pipe_mapper
+    - Fittings detected by angle calculation at vertices
+    - Empty/invalid JSON returns empty outputs gracefully
+
+Error Handling:
+    - Invalid routes_json logs warning and returns empty outputs
+    - Invalid type_overrides_json uses defaults with warning
+    - Missing fields in route data are skipped with warning
+    - run=False returns immediately with "Disabled" info message
+
+Author: Fernando Maytorena
+Version: 1.0.0
+"""
+
+# =============================================================================
+# Imports
+# =============================================================================
+
+# Standard library
+import sys
+import json
+import traceback
+
+# .NET / CLR
+import clr
+clr.AddReference("Grasshopper")
+clr.AddReference("RhinoCommon")
+
+from System import Array
+from System.Collections.Generic import List
+
+# Rhino / Grasshopper
+import Rhino
+import Rhino.Geometry as rg
+import Grasshopper
+from Grasshopper import DataTree
+from Grasshopper.Kernel.Data import GH_Path
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+COMPONENT_NAME = "MEP Pipe Creator"
+COMPONENT_NICKNAME = "MEP-Pipes"
+COMPONENT_MESSAGE = "v1.0.0"
+COMPONENT_CATEGORY = "TimberFraming"
+COMPONENT_SUBCATEGORY = "MEP"
+
+# =============================================================================
+# Logging Utilities
+# =============================================================================
+
+def log_message(message, level="info"):
+    """Log to console and optionally add GH runtime message.
+
+    Args:
+        message: The message to log
+        level: One of "info", "debug", "warning", "error", "remark"
+    """
+    # Always print to console (captured by 'out' parameter and log files)
+    print(f"[{level.upper()}] {message}")
+
+    # Add to GH component UI for warnings and errors
+    if level == "warning":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Warning, message)
+    elif level == "error":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Error, message)
+    elif level == "remark":
+        ghenv.Component.AddRuntimeMessage(
+            Grasshopper.Kernel.GH_RuntimeMessageLevel.Remark, message)
+
+
+def log_debug(message):
+    """Log debug message (console only)."""
+    print(f"[DEBUG] {message}")
+
+
+def log_info(message):
+    """Log info message (console only)."""
+    print(f"[INFO] {message}")
+
+
+def log_warning(message):
+    """Log warning message (console + GH UI)."""
+    log_message(message, "warning")
+
+
+def log_error(message):
+    """Log error message (console + GH UI)."""
+    log_message(message, "error")
+
+# =============================================================================
+# Component Setup
+# =============================================================================
+
+def setup_component():
+    """Initialize and configure the Grasshopper component.
+
+    This function handles:
+    1. Setting component metadata (name, category, etc.)
+    2. Configuring input parameter names, descriptions, and access
+    3. Configuring output parameter names and descriptions
+
+    Note: Output[0] is reserved for GH's internal 'out' - start from Output[1]
+
+    IMPORTANT: Type Hints cannot be set programmatically in Rhino 8.
+    They must be configured via UI: Right-click input -> Type hint -> Select type
+    """
+    # Component metadata
+    ghenv.Component.Name = COMPONENT_NAME
+    ghenv.Component.NickName = COMPONENT_NICKNAME
+    ghenv.Component.Message = COMPONENT_MESSAGE
+    ghenv.Component.Category = COMPONENT_CATEGORY
+    ghenv.Component.SubCategory = COMPONENT_SUBCATEGORY
+
+    # Configure inputs
+    # IMPORTANT: In GHPython, the NickName becomes the Python variable name!
+    # Format: (DisplayName, variable_name, Description, Access)
+    # - Name: Human-readable display name (shown in tooltips)
+    # - NickName: MUST be valid Python identifier - this IS the variable name in code
+    # - Access: item, list, or tree
+    #
+    # NOTE: Type Hints must be set via GH UI (right-click -> Type hint)
+    # They cannot be set programmatically from within the script.
+    inputs = ghenv.Component.Params.Input
+
+    input_config = [
+        # (DisplayName, variable_name, Description, Access)
+        ("Routes JSON", "routes_json", "JSON string with computed routes from OAHS router",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Type Overrides JSON", "type_overrides_json", "Optional JSON with custom pipe type mappings",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Create Fittings", "create_fittings", "Enable fitting detection at direction changes (default True)",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+        ("Run", "run", "Boolean to trigger execution",
+         Grasshopper.Kernel.GH_ParamAccess.item),
+    ]
+
+    for i, (name, nick, desc, access) in enumerate(input_config):
+        if i < inputs.Count:
+            inputs[i].Name = name
+            inputs[i].NickName = nick
+            inputs[i].Description = desc
+            inputs[i].Access = access
+
+    # Configure outputs (start from index 1, as 0 is reserved for 'out')
+    # IMPORTANT: NickName becomes the Python variable name - must match code!
+    outputs = ghenv.Component.Params.Output
+
+    output_config = [
+        # (DisplayName, variable_name, Description) - indices start at 1
+        ("Pipe Specs JSON", "pipe_specs_json", "JSON string with pipe specifications for Revit"),
+        ("Fitting Specs JSON", "fitting_specs_json", "JSON string with fitting specifications"),
+        ("Curves", "curves", "LineCurve visualization of pipe paths (DataTree, one branch per route)"),
+        ("Fitting Points", "fitting_pts", "Point3d markers at fitting locations"),
+        ("Info", "info", "Diagnostic summary string"),
+    ]
+
+    for i, (name, nick, desc) in enumerate(output_config):
+        idx = i + 1  # Skip Output[0]
+        if idx < outputs.Count:
+            outputs[idx].Name = name
+            outputs[idx].NickName = nick
+            outputs[idx].Description = desc
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def get_factory():
+    """Get RhinoCommonFactory instance for geometry creation.
+
+    Returns:
+        RhinoCommonFactory instance
+
+    Raises:
+        ImportError: If timber_framing_generator is not installed
+    """
+    from src.timber_framing_generator.utils.geometry_factory import get_factory as _get_factory
+    return _get_factory()
+
+
+def validate_inputs(routes_json_input, run_input):
+    """Validate component inputs.
+
+    Args:
+        routes_json_input: Routes JSON string to validate
+        run_input: Run boolean input
+
+    Returns:
+        tuple: (is_valid, error_message)
+    """
+    if not run_input:
+        return False, "Set run=True to execute pipe creation"
+
+    if not routes_json_input:
+        return False, "Missing routes_json input"
+
+    # Validate JSON parsing
+    try:
+        data = json.loads(routes_json_input)
+        if not isinstance(data, dict):
+            return False, "routes_json must be a JSON object"
+        if "routes" not in data:
+            return False, "routes_json missing 'routes' key"
+    except json.JSONDecodeError as e:
+        return False, f"Invalid routes_json: {e}"
+
+    return True, None
+
+
+def create_pipe_curves(pipe_result, factory):
+    """Create LineCurve geometry for pipe segments.
+
+    Args:
+        pipe_result: PipeCreatorResult with pipes list
+        factory: RhinoCommonFactory instance
+
+    Returns:
+        tuple: (DataTree of curves organized by route, route_to_index mapping)
+    """
+    curves_tree = DataTree[object]()
+    route_indices = {}  # route_id -> branch index
+
+    for pipe in pipe_result.pipes:
+        route_id = pipe.route_id
+
+        # Get or create branch index for this route
+        if route_id not in route_indices:
+            route_indices[route_id] = len(route_indices)
+        branch_idx = route_indices[route_id]
+        path = GH_Path(branch_idx)
+
+        # Create LineCurve from pipe endpoints
+        try:
+            start = pipe.start_point
+            end = pipe.end_point
+
+            line_curve = factory.create_line_curve(
+                (float(start[0]), float(start[1]), float(start[2])),
+                (float(end[0]), float(end[1]), float(end[2]))
+            )
+            if line_curve is not None:
+                curves_tree.Add(line_curve, path)
+        except Exception as e:
+            log_debug(f"Error creating pipe curve for {pipe.id}: {e}")
+            continue
+
+    return curves_tree, route_indices
+
+
+def create_fitting_points(pipe_result, factory):
+    """Create Point3d geometry for fitting locations.
+
+    Args:
+        pipe_result: PipeCreatorResult with fittings list
+        factory: RhinoCommonFactory instance
+
+    Returns:
+        List of Point3d objects at fitting locations
+    """
+    points = []
+
+    for fitting in pipe_result.fittings:
+        try:
+            loc = fitting.location
+            pt = factory.create_point3d(
+                float(loc[0]),
+                float(loc[1]),
+                float(loc[2])
+            )
+            if pt is not None:
+                points.append(pt)
+        except Exception as e:
+            log_debug(f"Error creating fitting point for {fitting.id}: {e}")
+            continue
+
+    return points
+
+
+def process_routes(routes_json_str, type_overrides_str, create_fittings_flag):
+    """Process route data and generate pipe/fitting specifications.
+
+    Args:
+        routes_json_str: JSON string with routes data
+        type_overrides_str: Optional JSON string with type overrides
+        create_fittings_flag: Boolean to enable fitting detection
+
+    Returns:
+        tuple: (pipe_specs_json, fitting_specs_json, curves_tree, fitting_pts, info_string)
+    """
+    log_info("Starting pipe creation processing")
+
+    # Import the revit_pipe_mapper module
+    try:
+        from src.timber_framing_generator.mep.routing.revit_pipe_mapper import (
+            process_routes_to_pipes,
+            detect_junctions,
+        )
+    except ImportError as e:
+        log_error(f"Could not import revit_pipe_mapper: {e}")
+        return "", "", DataTree[object](), [], f"Import error: {e}"
+
+    # Get geometry factory
+    try:
+        factory = get_factory()
+    except ImportError as e:
+        log_error(f"Could not import geometry factory: {e}")
+        return "", "", DataTree[object](), [], f"Import error: {e}"
+
+    # Process routes to pipe specifications
+    pipe_result = process_routes_to_pipes(
+        routes_json_str,
+        type_overrides_str if type_overrides_str else None,
+        create_fittings_flag
+    )
+
+    log_info(f"Generated {len(pipe_result.pipes)} pipes, {len(pipe_result.fittings)} fittings")
+
+    # Create output JSON strings
+    pipe_specs_dict = {
+        "pipes": [p.to_dict() for p in pipe_result.pipes],
+        "summary": {
+            "total_pipes": len(pipe_result.pipes),
+        }
+    }
+    pipe_specs_json = json.dumps(pipe_specs_dict, indent=2)
+
+    fitting_specs_dict = {
+        "fittings": [f.to_dict() for f in pipe_result.fittings],
+        "summary": {
+            "total_fittings": len(pipe_result.fittings),
+        }
+    }
+    fitting_specs_json = json.dumps(fitting_specs_dict, indent=2)
+
+    # Create visualization geometry
+    curves_tree, route_indices = create_pipe_curves(pipe_result, factory)
+    fitting_pts = create_fitting_points(pipe_result, factory)
+
+    # Detect inter-route junctions
+    junctions = detect_junctions(routes_json_str)
+
+    # Build info string
+    info_lines = [
+        f"Pipes generated: {len(pipe_result.pipes)}",
+        f"Fittings detected: {len(pipe_result.fittings)}",
+        f"Inter-route junctions: {len(junctions)}",
+        f"Routes processed: {len(route_indices)}",
+    ]
+
+    if pipe_result.warnings:
+        info_lines.append(f"Warnings: {len(pipe_result.warnings)}")
+        for warning in pipe_result.warnings[:5]:  # Show first 5 warnings
+            info_lines.append(f"  - {warning}")
+        if len(pipe_result.warnings) > 5:
+            info_lines.append(f"  ... and {len(pipe_result.warnings) - 5} more")
+
+    info_string = "\n".join(info_lines)
+    log_info(f"Pipe creation complete: {len(pipe_result.pipes)} pipes, {len(pipe_result.fittings)} fittings")
+
+    return pipe_specs_json, fitting_specs_json, curves_tree, fitting_pts, info_string
+
+# =============================================================================
+# Main Function
+# =============================================================================
+
+def main():
+    """Main entry point for the component.
+
+    Coordinates the overall workflow:
+    1. Setup component metadata
+    2. Validate inputs
+    3. Process route data
+    4. Return pipe specifications and visualization geometry
+
+    Returns:
+        tuple: (pipe_specs_json, fitting_specs_json, curves, fitting_pts, info) or empty outputs on failure
+    """
+    # Setup component
+    setup_component()
+
+    # Initialize empty outputs
+    empty_curves = DataTree[object]()
+    empty_points = []
+
+    try:
+        # Get inputs (these come from GH component inputs)
+        # Use globals() to check if variables are defined
+        routes_json_input = routes_json if 'routes_json' in dir() else None
+        type_overrides_input = type_overrides_json if 'type_overrides_json' in dir() else ""
+        create_fittings_input = create_fittings if 'create_fittings' in dir() else True
+        run_input = run if 'run' in dir() else False
+
+        # Handle None/unset boolean inputs with defaults
+        if create_fittings_input is None:
+            create_fittings_input = True
+
+        # Handle None type overrides as empty string
+        if type_overrides_input is None:
+            type_overrides_input = ""
+
+        # Validate inputs
+        is_valid, error_msg = validate_inputs(routes_json_input, run_input)
+        if not is_valid:
+            if error_msg and "run=True" not in error_msg:
+                log_warning(error_msg)
+            return "", "", empty_curves, empty_points, error_msg or "Disabled"
+
+        # Process routes
+        pipe_specs_json, fitting_specs_json, curves_tree, fitting_pts, info_string = process_routes(
+            routes_json_input,
+            type_overrides_input,
+            create_fittings_input
+        )
+
+        return pipe_specs_json, fitting_specs_json, curves_tree, fitting_pts, info_string
+
+    except Exception as e:
+        log_error(f"Unexpected error: {str(e)}")
+        log_debug(traceback.format_exc())
+        return "", "", empty_curves, empty_points, f"Error: {str(e)}"
+
+# =============================================================================
+# Execution
+# =============================================================================
+
+if __name__ == "__main__":
+    # Execute main and assign to output variables
+    # These variable names must match your GH component outputs
+    pipe_specs_json, fitting_specs_json, curves, fitting_pts, info = main()

--- a/src/timber_framing_generator/mep/routing/revit_pipe_mapper.py
+++ b/src/timber_framing_generator/mep/routing/revit_pipe_mapper.py
@@ -1,0 +1,603 @@
+# File: src/timber_framing_generator/mep/routing/revit_pipe_mapper.py
+"""
+Revit pipe/conduit type mapping for MEP routes.
+
+Maps OAHS route system types to Revit pipe/conduit configurations,
+detects fittings at direction changes, and generates specifications
+for Revit element creation via Rhino.Inside.Revit.
+
+Key Features:
+1. System type to Revit type mapping
+2. Direction change detection for elbow fittings
+3. Junction detection for tee fittings
+4. Size normalization to Revit nominal sizes
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import logging
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass, field
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+# System type to Revit configuration mapping
+REVIT_PIPE_TYPES: Dict[str, Dict[str, str]] = {
+    "sanitary_drain": {
+        "category": "Pipe",
+        "system_type": "Sanitary",
+        "pipe_type": "Cast Iron - No Hub",
+        "fitting_family": "Generic - CI",
+    },
+    "sanitary_vent": {
+        "category": "Pipe",
+        "system_type": "Sanitary",
+        "pipe_type": "PVC - Schedule 40",
+        "fitting_family": "Generic - PVC",
+    },
+    "dhw": {
+        "category": "Pipe",
+        "system_type": "Domestic Hot Water",
+        "pipe_type": "Copper Type L",
+        "fitting_family": "Generic - Copper",
+    },
+    "dcw": {
+        "category": "Pipe",
+        "system_type": "Domestic Cold Water",
+        "pipe_type": "PEX",
+        "fitting_family": "Generic - PEX",
+    },
+    "power": {
+        "category": "Conduit",
+        "system_type": "Power",
+        "conduit_type": "EMT",
+        "fitting_family": "Generic - EMT",
+    },
+    "data": {
+        "category": "Conduit",
+        "system_type": "Communications",
+        "conduit_type": "EMT",
+        "fitting_family": "Generic - EMT",
+    },
+    "lighting": {
+        "category": "Conduit",
+        "system_type": "Power - Lighting",
+        "conduit_type": "EMT",
+        "fitting_family": "Generic - EMT",
+    },
+}
+
+# Default configuration for unknown system types
+DEFAULT_PIPE_CONFIG: Dict[str, str] = {
+    "category": "Pipe",
+    "system_type": "Other",
+    "pipe_type": "Default",
+    "fitting_family": "Generic",
+}
+
+# Nominal pipe sizes (OD in feet to nominal size string)
+NOMINAL_SIZES: Dict[float, str] = {
+    0.0729: '1/2"',
+    0.0875: '3/4"',
+    0.1104: '1"',
+    0.1396: '1-1/4"',
+    0.1583: '1-1/2"',
+    0.1979: '2"',
+    0.2917: '3"',
+    0.375: '4"',
+}
+
+# Angle tolerances for fitting detection (degrees)
+ELBOW_90_MIN = 85.0
+ELBOW_90_MAX = 95.0
+ELBOW_45_MIN = 40.0
+ELBOW_45_MAX = 50.0
+
+
+# ============================================================================
+# Enums
+# ============================================================================
+
+class FittingType(Enum):
+    """Types of pipe/conduit fittings."""
+    ELBOW_90 = "elbow_90"
+    ELBOW_45 = "elbow_45"
+    TEE = "tee"
+    WYE = "wye"
+    CROSS = "cross"
+    COUPLING = "coupling"
+    CAP = "cap"
+    CUSTOM = "custom"
+
+
+# ============================================================================
+# Data Classes
+# ============================================================================
+
+@dataclass
+class PipeSpec:
+    """Specification for a single pipe segment."""
+    id: str
+    route_id: str
+    system_type: str
+    start_point: Tuple[float, float, float]
+    end_point: Tuple[float, float, float]
+    diameter: float
+    revit_config: Dict[str, str]
+    nominal_size: str = ""
+    length: float = 0.0
+
+    def __post_init__(self):
+        """Calculate derived values."""
+        if not self.nominal_size:
+            self.nominal_size = get_nominal_size(self.diameter)
+        if self.length == 0:
+            self.length = self._calculate_length()
+
+    def _calculate_length(self) -> float:
+        """Calculate pipe length from endpoints."""
+        dx = self.end_point[0] - self.start_point[0]
+        dy = self.end_point[1] - self.start_point[1]
+        dz = self.end_point[2] - self.start_point[2]
+        return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "route_id": self.route_id,
+            "system_type": self.system_type,
+            "start_point": list(self.start_point),
+            "end_point": list(self.end_point),
+            "diameter": self.diameter,
+            "nominal_size": self.nominal_size,
+            "length": self.length,
+            "revit_config": self.revit_config,
+        }
+
+
+@dataclass
+class FittingSpec:
+    """Specification for a pipe fitting."""
+    id: str
+    fitting_type: FittingType
+    location: Tuple[float, float, float]
+    connected_pipes: List[str]
+    angle: Optional[float] = None
+    system_type: str = ""
+    fitting_family: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "type": self.fitting_type.value,
+            "location": list(self.location),
+            "connected_pipes": self.connected_pipes,
+            "angle": self.angle,
+            "system_type": self.system_type,
+            "fitting_family": self.fitting_family,
+        }
+
+
+@dataclass
+class PipeCreatorResult:
+    """Result from pipe creation processing."""
+    pipes: List[PipeSpec] = field(default_factory=list)
+    fittings: List[FittingSpec] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "pipes": [p.to_dict() for p in self.pipes],
+            "fittings": [f.to_dict() for f in self.fittings],
+            "warnings": self.warnings,
+            "summary": {
+                "total_pipes": len(self.pipes),
+                "total_fittings": len(self.fittings),
+                "total_warnings": len(self.warnings),
+            }
+        }
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+def get_revit_config(system_type: str, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    """
+    Get Revit configuration for a system type.
+
+    Args:
+        system_type: MEP system type (e.g., "sanitary_drain", "dhw")
+        overrides: Optional dictionary of type overrides
+
+    Returns:
+        Dictionary with Revit configuration
+    """
+    # Normalize system type
+    sys_key = system_type.lower().strip() if system_type else "default"
+
+    # Check overrides first
+    if overrides and sys_key in overrides:
+        config = DEFAULT_PIPE_CONFIG.copy()
+        config.update(overrides[sys_key])
+        return config
+
+    # Use standard mapping
+    if sys_key in REVIT_PIPE_TYPES:
+        return REVIT_PIPE_TYPES[sys_key].copy()
+
+    # Default config
+    logger.warning(f"Unknown system type '{system_type}', using default config")
+    return DEFAULT_PIPE_CONFIG.copy()
+
+
+def get_nominal_size(diameter_ft: float) -> str:
+    """
+    Get nominal pipe size string from diameter.
+
+    Args:
+        diameter_ft: Pipe outer diameter in feet
+
+    Returns:
+        Nominal size string (e.g., '1-1/2"')
+    """
+    if not diameter_ft or diameter_ft <= 0:
+        return "Unknown"
+
+    # Find closest match
+    best_match = "Custom"
+    best_diff = float('inf')
+
+    for od, nominal in NOMINAL_SIZES.items():
+        diff = abs(od - diameter_ft)
+        if diff < best_diff:
+            best_diff = diff
+            best_match = nominal
+
+    # If very different from any standard size, mark as custom
+    if best_diff > 0.02:  # More than ~1/4" off
+        return f'{diameter_ft * 12:.2f}" (custom)'
+
+    return best_match
+
+
+def calculate_angle(
+    p1: Tuple[float, float, float],
+    p2: Tuple[float, float, float],
+    p3: Tuple[float, float, float]
+) -> float:
+    """
+    Calculate angle at p2 between segments p1-p2 and p2-p3.
+
+    Args:
+        p1: First point
+        p2: Vertex point (where angle is measured)
+        p3: Third point
+
+    Returns:
+        Angle in degrees (0-180)
+    """
+    # Vectors from p2
+    v1 = (p1[0] - p2[0], p1[1] - p2[1], p1[2] - p2[2])
+    v2 = (p3[0] - p2[0], p3[1] - p2[1], p3[2] - p2[2])
+
+    # Magnitudes
+    mag1 = math.sqrt(v1[0]**2 + v1[1]**2 + v1[2]**2)
+    mag2 = math.sqrt(v2[0]**2 + v2[1]**2 + v2[2]**2)
+
+    if mag1 == 0 or mag2 == 0:
+        return 180.0  # Degenerate - treat as straight
+
+    # Dot product
+    dot = v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2]
+
+    # Cosine of angle
+    cos_angle = dot / (mag1 * mag2)
+    cos_angle = max(-1.0, min(1.0, cos_angle))  # Clamp for numerical stability
+
+    # Angle in degrees
+    angle = math.degrees(math.acos(cos_angle))
+
+    return angle
+
+
+def detect_fitting_type(angle: float) -> Optional[FittingType]:
+    """
+    Detect fitting type from angle.
+
+    Args:
+        angle: Angle in degrees at direction change
+
+    Returns:
+        FittingType or None if straight (no fitting needed)
+    """
+    # Straight segment (no fitting needed)
+    if angle >= 175:
+        return None
+
+    # 90 degree elbow
+    if ELBOW_90_MIN <= angle <= ELBOW_90_MAX:
+        return FittingType.ELBOW_90
+
+    # 45 degree elbow
+    if ELBOW_45_MIN <= angle <= ELBOW_45_MAX:
+        return FittingType.ELBOW_45
+
+    # Custom angle fitting
+    return FittingType.CUSTOM
+
+
+# ============================================================================
+# Route Processing
+# ============================================================================
+
+def process_route(
+    route: Dict[str, Any],
+    route_index: int,
+    type_overrides: Optional[Dict[str, Any]] = None,
+    create_fittings: bool = True
+) -> Tuple[List[PipeSpec], List[FittingSpec], List[str]]:
+    """
+    Process a single route into pipe and fitting specs.
+
+    Args:
+        route: Route dictionary from routes_json
+        route_index: Index for ID generation
+        type_overrides: Optional pipe type overrides
+        create_fittings: Whether to detect and create fittings
+
+    Returns:
+        Tuple of (pipes, fittings, warnings)
+    """
+    pipes = []
+    fittings = []
+    warnings = []
+
+    route_id = route.get("route_id", f"route_{route_index:03d}")
+    system_type = route.get("system_type", "default")
+    pipe_diameter = route.get("pipe_size", 0.0833)  # Default 1"
+
+    # Get Revit configuration
+    revit_config = get_revit_config(system_type, type_overrides)
+
+    # Extract path points from segments
+    segments = route.get("segments", [])
+    if not segments:
+        warnings.append(f"Route {route_id} has no segments")
+        return pipes, fittings, warnings
+
+    # Build point sequence
+    path_points = []
+    for seg in segments:
+        start = seg.get("start", [])
+        end = seg.get("end", [])
+
+        if start and len(start) >= 3:
+            point = (float(start[0]), float(start[1]), float(start[2]))
+            if not path_points or path_points[-1] != point:
+                path_points.append(point)
+
+        if end and len(end) >= 3:
+            point = (float(end[0]), float(end[1]), float(end[2]))
+            if not path_points or path_points[-1] != point:
+                path_points.append(point)
+
+    if len(path_points) < 2:
+        warnings.append(f"Route {route_id} has fewer than 2 points")
+        return pipes, fittings, warnings
+
+    # Create pipe specs for each segment
+    for i in range(len(path_points) - 1):
+        pipe_id = f"pipe_{route_id}_{i:03d}"
+        pipe = PipeSpec(
+            id=pipe_id,
+            route_id=route_id,
+            system_type=system_type,
+            start_point=path_points[i],
+            end_point=path_points[i + 1],
+            diameter=pipe_diameter,
+            revit_config=revit_config,
+        )
+        pipes.append(pipe)
+
+    # Detect fittings at direction changes
+    if create_fittings and len(path_points) >= 3:
+        for i in range(1, len(path_points) - 1):
+            p1 = path_points[i - 1]
+            p2 = path_points[i]
+            p3 = path_points[i + 1]
+
+            angle = calculate_angle(p1, p2, p3)
+            fitting_type = detect_fitting_type(angle)
+
+            if fitting_type:
+                fitting_id = f"fitting_{route_id}_{i:03d}"
+                # Get connected pipe IDs
+                connected = [
+                    f"pipe_{route_id}_{i-1:03d}",
+                    f"pipe_{route_id}_{i:03d}"
+                ]
+
+                fitting = FittingSpec(
+                    id=fitting_id,
+                    fitting_type=fitting_type,
+                    location=p2,
+                    connected_pipes=connected,
+                    angle=angle,
+                    system_type=system_type,
+                    fitting_family=revit_config.get("fitting_family", "Generic"),
+                )
+                fittings.append(fitting)
+
+                if fitting_type == FittingType.CUSTOM:
+                    warnings.append(
+                        f"Route {route_id}: Non-standard angle {angle:.1f}° at point {i}"
+                    )
+
+    return pipes, fittings, warnings
+
+
+def process_routes_to_pipes(
+    routes_json: str,
+    type_overrides: Optional[str] = None,
+    create_fittings: bool = True
+) -> PipeCreatorResult:
+    """
+    Convert OAHS routes to pipe/fitting specifications.
+
+    Args:
+        routes_json: JSON string from gh_mep_router
+        type_overrides: Optional JSON string with pipe type overrides
+        create_fittings: Whether to create fitting specs
+
+    Returns:
+        PipeCreatorResult with pipes, fittings, and warnings
+    """
+    logger.info("Processing routes to pipe specifications")
+
+    result = PipeCreatorResult()
+
+    # Parse routes
+    try:
+        data = json.loads(routes_json)
+    except json.JSONDecodeError as e:
+        result.warnings.append(f"Invalid routes JSON: {e}")
+        return result
+
+    routes = data.get("routes", [])
+    if not routes:
+        result.warnings.append("No routes found in routes_json")
+        return result
+
+    # Parse overrides if provided
+    overrides = None
+    if type_overrides:
+        try:
+            overrides = json.loads(type_overrides)
+        except json.JSONDecodeError:
+            result.warnings.append("Invalid type_overrides JSON, using defaults")
+
+    # Process each route
+    for i, route in enumerate(routes):
+        try:
+            pipes, fittings, warnings = process_route(
+                route, i, overrides, create_fittings
+            )
+            result.pipes.extend(pipes)
+            result.fittings.extend(fittings)
+            result.warnings.extend(warnings)
+        except Exception as e:
+            route_id = route.get("route_id", f"route_{i}")
+            result.warnings.append(f"Error processing {route_id}: {e}")
+            logger.exception(f"Error processing route {route_id}")
+
+    logger.info(
+        f"Generated {len(result.pipes)} pipes, "
+        f"{len(result.fittings)} fittings, "
+        f"{len(result.warnings)} warnings"
+    )
+
+    return result
+
+
+def detect_junctions(routes_json: str, tolerance: float = 0.01) -> List[Dict[str, Any]]:
+    """
+    Detect junction points where multiple routes meet.
+
+    Args:
+        routes_json: JSON string with routes
+        tolerance: Distance tolerance for point matching (feet)
+
+    Returns:
+        List of junction dictionaries with location and connected routes
+    """
+    # Parse routes
+    try:
+        data = json.loads(routes_json)
+    except json.JSONDecodeError:
+        return []
+
+    routes = data.get("routes", [])
+
+    # Collect all endpoints
+    endpoints = []  # List of (point, route_id, is_start)
+
+    for route in routes:
+        route_id = route.get("route_id", "unknown")
+        segments = route.get("segments", [])
+
+        if segments:
+            # Start point
+            first_seg = segments[0]
+            start = first_seg.get("start", [])
+            if start and len(start) >= 3:
+                endpoints.append((
+                    (float(start[0]), float(start[1]), float(start[2])),
+                    route_id,
+                    True
+                ))
+
+            # End point
+            last_seg = segments[-1]
+            end = last_seg.get("end", [])
+            if end and len(end) >= 3:
+                endpoints.append((
+                    (float(end[0]), float(end[1]), float(end[2])),
+                    route_id,
+                    False
+                ))
+
+    # Find junction points (endpoints within tolerance)
+    junctions = []
+    used = set()
+
+    for i, (pt1, rid1, is_start1) in enumerate(endpoints):
+        if i in used:
+            continue
+
+        connected = [(rid1, is_start1)]
+        location = pt1
+
+        for j, (pt2, rid2, is_start2) in enumerate(endpoints):
+            if j <= i or j in used:
+                continue
+
+            # Check distance
+            dx = pt1[0] - pt2[0]
+            dy = pt1[1] - pt2[1]
+            dz = pt1[2] - pt2[2]
+            dist = math.sqrt(dx*dx + dy*dy + dz*dz)
+
+            if dist <= tolerance:
+                connected.append((rid2, is_start2))
+                used.add(j)
+
+        # Create junction if multiple routes meet
+        if len(connected) >= 2:
+            junctions.append({
+                "id": f"junction_{len(junctions):03d}",
+                "location": list(location),
+                "connected_routes": [
+                    {"route_id": rid, "at_start": is_start}
+                    for rid, is_start in connected
+                ],
+                "fitting_type": "tee" if len(connected) == 2 else "cross",
+            })
+
+    logger.info(f"Detected {len(junctions)} junction points")
+    return junctions

--- a/tests/mep/routing/test_revit_pipe_mapper.py
+++ b/tests/mep/routing/test_revit_pipe_mapper.py
@@ -1,0 +1,527 @@
+# File: tests/mep/routing/test_revit_pipe_mapper.py
+"""
+Tests for Revit pipe/conduit mapping module.
+
+Tests the route-to-pipe conversion, fitting detection,
+and Revit configuration mapping.
+"""
+
+import pytest
+import json
+import math
+
+from src.timber_framing_generator.mep.routing.revit_pipe_mapper import (
+    get_revit_config,
+    get_nominal_size,
+    calculate_angle,
+    detect_fitting_type,
+    process_route,
+    process_routes_to_pipes,
+    detect_junctions,
+    FittingType,
+    PipeSpec,
+    FittingSpec,
+    PipeCreatorResult,
+    REVIT_PIPE_TYPES,
+    DEFAULT_PIPE_CONFIG,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def sample_routes_json():
+    """Sample routes JSON with multiple segments."""
+    return json.dumps({
+        "routes": [
+            {
+                "route_id": "route_001",
+                "system_type": "sanitary_drain",
+                "pipe_size": 0.1583,  # 1.5" pipe
+                "segments": [
+                    {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                    {"start": [5.0, 0.0, 4.0], "end": [5.0, 5.0, 4.0]},  # 90 degree turn
+                ],
+            },
+        ]
+    })
+
+
+@pytest.fixture
+def straight_route_json():
+    """Route with no direction changes."""
+    return json.dumps({
+        "routes": [
+            {
+                "route_id": "straight_001",
+                "system_type": "dhw",
+                "pipe_size": 0.0729,  # 1/2" pipe
+                "segments": [
+                    {"start": [0.0, 0.0, 4.0], "end": [10.0, 0.0, 4.0]},
+                ],
+            },
+        ]
+    })
+
+
+@pytest.fixture
+def multiple_routes_json():
+    """Multiple routes for junction detection."""
+    return json.dumps({
+        "routes": [
+            {
+                "route_id": "route_a",
+                "system_type": "dcw",
+                "segments": [
+                    {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                ],
+            },
+            {
+                "route_id": "route_b",
+                "system_type": "dcw",
+                "segments": [
+                    {"start": [5.0, 0.0, 4.0], "end": [5.0, 5.0, 4.0]},  # Meets route_a at end
+                ],
+            },
+        ]
+    })
+
+
+# ============================================================================
+# Revit Configuration Tests
+# ============================================================================
+
+class TestGetRevitConfig:
+    """Tests for Revit configuration mapping."""
+
+    def test_sanitary_drain_config(self):
+        """Sanitary drain maps to correct Revit config."""
+        config = get_revit_config("sanitary_drain")
+
+        assert config["category"] == "Pipe"
+        assert config["system_type"] == "Sanitary"
+        assert "Cast Iron" in config["pipe_type"]
+
+    def test_dhw_config(self):
+        """DHW maps to domestic hot water config."""
+        config = get_revit_config("dhw")
+
+        assert config["category"] == "Pipe"
+        assert config["system_type"] == "Domestic Hot Water"
+
+    def test_power_config(self):
+        """Power maps to conduit config."""
+        config = get_revit_config("power")
+
+        assert config["category"] == "Conduit"
+        assert config["system_type"] == "Power"
+
+    def test_unknown_uses_default(self):
+        """Unknown system type uses default config."""
+        config = get_revit_config("unknown_type")
+
+        assert config == DEFAULT_PIPE_CONFIG
+
+    def test_override_applied(self):
+        """Custom overrides are applied."""
+        overrides = {
+            "sanitary_drain": {
+                "pipe_type": "Custom PVC",
+            }
+        }
+        config = get_revit_config("sanitary_drain", overrides)
+
+        assert config["pipe_type"] == "Custom PVC"
+
+    def test_case_insensitive(self):
+        """System type lookup is case insensitive."""
+        config1 = get_revit_config("DHW")
+        config2 = get_revit_config("dhw")
+        config3 = get_revit_config("Dhw")
+
+        assert config1 == config2 == config3
+
+
+class TestGetNominalSize:
+    """Tests for nominal pipe size mapping."""
+
+    def test_half_inch(self):
+        """1/2" pipe identified correctly."""
+        size = get_nominal_size(0.0729)
+        assert '1/2"' in size
+
+    def test_one_inch(self):
+        """1" pipe identified correctly."""
+        size = get_nominal_size(0.1104)
+        assert '1"' in size
+
+    def test_one_and_half_inch(self):
+        """1-1/2" pipe identified correctly."""
+        size = get_nominal_size(0.1583)
+        assert '1-1/2"' in size
+
+    def test_two_inch(self):
+        """2" pipe identified correctly."""
+        size = get_nominal_size(0.1979)
+        assert '2"' in size
+
+    def test_custom_size(self):
+        """Non-standard size marked as custom."""
+        size = get_nominal_size(0.5)  # Very large, non-standard
+        assert "custom" in size.lower()
+
+    def test_zero_returns_unknown(self):
+        """Zero diameter returns Unknown."""
+        size = get_nominal_size(0)
+        assert size == "Unknown"
+
+
+# ============================================================================
+# Angle Calculation Tests
+# ============================================================================
+
+class TestCalculateAngle:
+    """Tests for angle calculation between segments."""
+
+    def test_right_angle(self):
+        """90 degree angle detected correctly."""
+        p1 = (0.0, 0.0, 0.0)
+        p2 = (5.0, 0.0, 0.0)
+        p3 = (5.0, 5.0, 0.0)
+
+        angle = calculate_angle(p1, p2, p3)
+        assert 89.0 < angle < 91.0
+
+    def test_straight_line(self):
+        """180 degree (straight) angle detected."""
+        p1 = (0.0, 0.0, 0.0)
+        p2 = (5.0, 0.0, 0.0)
+        p3 = (10.0, 0.0, 0.0)
+
+        angle = calculate_angle(p1, p2, p3)
+        assert angle > 175.0
+
+    def test_45_degree_angle(self):
+        """45 degree angle detected."""
+        p1 = (0.0, 0.0, 0.0)
+        p2 = (5.0, 0.0, 0.0)
+        # 45 degrees from X axis
+        p3 = (5.0 + 5.0 * math.cos(math.radians(45)),
+              5.0 * math.sin(math.radians(45)),
+              0.0)
+
+        angle = calculate_angle(p1, p2, p3)
+        # Should be 180 - 45 = 135 degrees (angle at vertex)
+        # Actually with these points it's 45 from the incoming direction
+        assert 130.0 < angle < 140.0
+
+    def test_zero_length_segment(self):
+        """Zero length segment returns 180 (straight)."""
+        p1 = (0.0, 0.0, 0.0)
+        p2 = (0.0, 0.0, 0.0)  # Same as p1
+        p3 = (5.0, 0.0, 0.0)
+
+        angle = calculate_angle(p1, p2, p3)
+        assert angle == 180.0
+
+
+class TestDetectFittingType:
+    """Tests for fitting type detection from angles."""
+
+    def test_90_degree_elbow(self):
+        """90 degree angle produces elbow_90."""
+        fitting = detect_fitting_type(90.0)
+        assert fitting == FittingType.ELBOW_90
+
+    def test_85_degree_is_elbow_90(self):
+        """85 degrees within tolerance for 90 elbow."""
+        fitting = detect_fitting_type(85.0)
+        assert fitting == FittingType.ELBOW_90
+
+    def test_45_degree_elbow(self):
+        """45 degree angle produces elbow_45."""
+        fitting = detect_fitting_type(45.0)
+        assert fitting == FittingType.ELBOW_45
+
+    def test_straight_no_fitting(self):
+        """Straight (>175 degrees) needs no fitting."""
+        fitting = detect_fitting_type(178.0)
+        assert fitting is None
+
+    def test_custom_angle(self):
+        """Non-standard angle produces custom fitting."""
+        fitting = detect_fitting_type(60.0)
+        assert fitting == FittingType.CUSTOM
+
+        fitting = detect_fitting_type(120.0)
+        assert fitting == FittingType.CUSTOM
+
+
+# ============================================================================
+# Route Processing Tests
+# ============================================================================
+
+class TestProcessRoute:
+    """Tests for single route processing."""
+
+    def test_basic_route_processing(self):
+        """Basic route produces pipes."""
+        route = {
+            "route_id": "test_001",
+            "system_type": "dhw",
+            "pipe_size": 0.0729,
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+            ],
+        }
+
+        pipes, fittings, warnings = process_route(route, 0)
+
+        assert len(pipes) == 1
+        assert pipes[0].route_id == "test_001"
+        assert pipes[0].system_type == "dhw"
+
+    def test_multi_segment_route(self):
+        """Multi-segment route produces multiple pipes."""
+        route = {
+            "route_id": "multi_001",
+            "system_type": "sanitary_drain",
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                {"start": [5.0, 0.0, 4.0], "end": [5.0, 5.0, 4.0]},
+            ],
+        }
+
+        pipes, fittings, warnings = process_route(route, 0, create_fittings=True)
+
+        assert len(pipes) == 2
+        # 90 degree turn should create a fitting
+        assert len(fittings) == 1
+        assert fittings[0].fitting_type == FittingType.ELBOW_90
+
+    def test_empty_segments_warning(self):
+        """Empty segments produces warning."""
+        route = {
+            "route_id": "empty_001",
+            "system_type": "dhw",
+            "segments": [],
+        }
+
+        pipes, fittings, warnings = process_route(route, 0)
+
+        assert len(pipes) == 0
+        assert len(warnings) == 1
+        assert "no segments" in warnings[0].lower()
+
+    def test_fitting_disabled(self):
+        """Fittings can be disabled."""
+        route = {
+            "route_id": "no_fit_001",
+            "system_type": "dcw",
+            "segments": [
+                {"start": [0.0, 0.0, 4.0], "end": [5.0, 0.0, 4.0]},
+                {"start": [5.0, 0.0, 4.0], "end": [5.0, 5.0, 4.0]},
+            ],
+        }
+
+        pipes, fittings, warnings = process_route(route, 0, create_fittings=False)
+
+        assert len(pipes) == 2
+        assert len(fittings) == 0  # No fittings when disabled
+
+
+class TestProcessRoutesToPipes:
+    """Tests for full route-to-pipes processing."""
+
+    def test_process_valid_routes(self, sample_routes_json):
+        """Valid routes JSON processes correctly."""
+        result = process_routes_to_pipes(sample_routes_json)
+
+        assert isinstance(result, PipeCreatorResult)
+        assert len(result.pipes) >= 1
+        assert "total_pipes" in result.to_dict()["summary"]
+
+    def test_process_straight_route(self, straight_route_json):
+        """Straight route has no fittings."""
+        result = process_routes_to_pipes(straight_route_json)
+
+        assert len(result.pipes) == 1
+        assert len(result.fittings) == 0
+
+    def test_invalid_json_warning(self):
+        """Invalid JSON adds warning."""
+        result = process_routes_to_pipes("not valid json")
+
+        assert len(result.warnings) > 0
+        assert "Invalid" in result.warnings[0]
+
+    def test_empty_routes_warning(self):
+        """Empty routes array adds warning."""
+        result = process_routes_to_pipes('{"routes": []}')
+
+        assert len(result.warnings) > 0
+        assert "No routes" in result.warnings[0]
+
+    def test_json_serialization(self, sample_routes_json):
+        """Result can be serialized to JSON."""
+        result = process_routes_to_pipes(sample_routes_json)
+        json_str = result.to_json()
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert "pipes" in parsed
+        assert "fittings" in parsed
+        assert "summary" in parsed
+
+
+# ============================================================================
+# Junction Detection Tests
+# ============================================================================
+
+class TestDetectJunctions:
+    """Tests for junction point detection."""
+
+    def test_detect_meeting_routes(self, multiple_routes_json):
+        """Routes meeting at same point detected as junction."""
+        junctions = detect_junctions(multiple_routes_json)
+
+        # Route A ends at (5,0,4), Route B starts at (5,0,4)
+        assert len(junctions) == 1
+        assert len(junctions[0]["connected_routes"]) == 2
+
+    def test_no_junctions_isolated_routes(self):
+        """Isolated routes have no junctions."""
+        routes_json = json.dumps({
+            "routes": [
+                {
+                    "route_id": "a",
+                    "segments": [{"start": [0, 0, 0], "end": [5, 0, 0]}],
+                },
+                {
+                    "route_id": "b",
+                    "segments": [{"start": [100, 100, 100], "end": [105, 100, 100]}],
+                },
+            ]
+        })
+
+        junctions = detect_junctions(routes_json)
+        assert len(junctions) == 0
+
+    def test_junction_fitting_type(self, multiple_routes_json):
+        """Junction has correct fitting type."""
+        junctions = detect_junctions(multiple_routes_json)
+
+        assert junctions[0]["fitting_type"] == "tee"
+
+    def test_invalid_json_returns_empty(self):
+        """Invalid JSON returns empty list."""
+        junctions = detect_junctions("invalid json")
+        assert junctions == []
+
+
+# ============================================================================
+# Data Class Tests
+# ============================================================================
+
+class TestPipeSpec:
+    """Tests for PipeSpec data class."""
+
+    def test_length_calculation(self):
+        """Pipe length calculated from endpoints."""
+        pipe = PipeSpec(
+            id="test",
+            route_id="route",
+            system_type="dhw",
+            start_point=(0.0, 0.0, 0.0),
+            end_point=(3.0, 4.0, 0.0),  # 3-4-5 triangle
+            diameter=0.0729,
+            revit_config={},
+        )
+
+        assert pipe.length == 5.0
+
+    def test_nominal_size_auto_set(self):
+        """Nominal size automatically set from diameter."""
+        pipe = PipeSpec(
+            id="test",
+            route_id="route",
+            system_type="dhw",
+            start_point=(0.0, 0.0, 0.0),
+            end_point=(5.0, 0.0, 0.0),
+            diameter=0.1583,  # 1-1/2"
+            revit_config={},
+        )
+
+        assert '1-1/2"' in pipe.nominal_size
+
+    def test_to_dict(self):
+        """Pipe converts to dictionary."""
+        pipe = PipeSpec(
+            id="test",
+            route_id="route",
+            system_type="dhw",
+            start_point=(0.0, 0.0, 0.0),
+            end_point=(5.0, 0.0, 0.0),
+            diameter=0.0729,
+            revit_config={"category": "Pipe"},
+        )
+
+        d = pipe.to_dict()
+        assert d["id"] == "test"
+        assert d["start_point"] == [0.0, 0.0, 0.0]
+        assert d["revit_config"]["category"] == "Pipe"
+
+
+class TestFittingSpec:
+    """Tests for FittingSpec data class."""
+
+    def test_to_dict(self):
+        """Fitting converts to dictionary."""
+        fitting = FittingSpec(
+            id="fit_001",
+            fitting_type=FittingType.ELBOW_90,
+            location=(5.0, 0.0, 4.0),
+            connected_pipes=["pipe_001", "pipe_002"],
+            angle=90.0,
+            system_type="dhw",
+            fitting_family="Generic - Copper",
+        )
+
+        d = fitting.to_dict()
+        assert d["id"] == "fit_001"
+        assert d["type"] == "elbow_90"
+        assert d["angle"] == 90.0
+        assert len(d["connected_pipes"]) == 2
+
+
+class TestPipeCreatorResult:
+    """Tests for PipeCreatorResult container."""
+
+    def test_empty_result(self):
+        """Empty result has correct structure."""
+        result = PipeCreatorResult()
+
+        d = result.to_dict()
+        assert d["summary"]["total_pipes"] == 0
+        assert d["summary"]["total_fittings"] == 0
+
+    def test_to_json(self):
+        """Result serializes to valid JSON."""
+        result = PipeCreatorResult()
+        result.pipes.append(PipeSpec(
+            id="p1",
+            route_id="r1",
+            system_type="dhw",
+            start_point=(0, 0, 0),
+            end_point=(5, 0, 0),
+            diameter=0.0729,
+            revit_config={},
+        ))
+
+        json_str = result.to_json()
+        parsed = json.loads(json_str)
+
+        assert len(parsed["pipes"]) == 1
+        assert parsed["summary"]["total_pipes"] == 1


### PR DESCRIPTION
## Summary
- Map MEP system types to Revit pipe/conduit configurations
- Detect fittings at direction changes (90° and 45° elbows)
- Detect junction points for tee fittings
- Generate pipe/fitting specifications for RiR creation

## Changes
- Add `src/timber_framing_generator/mep/routing/revit_pipe_mapper.py` - Pipe type mapping
- Add `scripts/gh_mep_pipe_creator.py` - GHPython component
- Add `tests/mep/routing/test_revit_pipe_mapper.py` - 40 tests
- Add `PRPs/PRP-021--mep-routing-pipe-creator.md` - Specification

## Test plan
- [x] 40 unit tests passing
- [ ] Load component in Grasshopper with Rhino.Inside.Revit
- [ ] Verify pipe specs JSON is correctly formatted
- [ ] Verify fitting detection at direction changes

## OAHS Implementation Complete! 🎉

This PR completes the 11-phase OAHS MEP routing solver implementation:
- Phase 1-5: Core algorithms (Hanan Grid, A*, MST)
- Phase 6-7: Zone routing and orchestration
- Phase 8: Sanitary post-processing
- Phase 9-11: Visualization and Revit integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)